### PR TITLE
Target Java 1.5. fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ still exists.
 
 ## Getting started
 
-Run `mvn package` from the toplevel directory to build dnsjava. JDK 1.4
+Run `mvn package` from the toplevel directory to build dnsjava. JDK 1.5
 or higher is required.
 
 ### Replacing the standard Java DNS functionality:
 
-Java versions from 1.4 to 1.8 can load DNS service providers at runtime. The
+Java versions from 1.5 to 1.8 can load DNS service providers at runtime. The
 functionality was [removed in JDK 9](https://bugs.openjdk.java.net/browse/JDK-8134577),
 a replacement is [requested](https://bugs.openjdk.java.net/browse/JDK-8192780),
 but so far has not been implemented.

--- a/build.xml
+++ b/build.xml
@@ -5,26 +5,26 @@
     <property name="dist_dir" value="${basedir}"/>
     <property name="tests_dir" value="${basedir}/tests"/>
     <property name="reports_dir" value="${basedir}/reports"/>
-    <property name="version" value="2.1.8"/>
+    <property name="version" value="3.0.0"/>
     <property name="jarname" value="dnsjava-${version}.jar"/>
     <property name="zipname" value="dnsjava-${version}.zip"/>
     <property name="targzname" value="dnsjava-${version}.tar.gz"/>
 
     <property name="j2se.javadoc"
-      value="http://download.oracle.com/javase/1.4.2/docs/api/"/>
+      value="https://docs.oracle.com/javase/1.5.0/docs/api/"/>
 
     <target name="all" description="Compile and Jar" depends="jar">
     </target>
 
     <target name="compile" description="Compile everything">
-	<javac destdir="${build_dir}" debug="true" target="1.4" source="1.4">
+	<javac destdir="${build_dir}" debug="true" target="1.5" source="1.5">
 	    <src path="${src_dir}"/>
 	    <exclude name="tests/**"/>
 	</javac>
     </target>
 
     <target name="spi" description="Compile the Name Service Provider code">
-	<javac destdir="${build_dir}" debug="true" target="1.4" source="1.4">
+	<javac destdir="${build_dir}" debug="true" target="1.5" source="1.5">
 	    <src path="${src_dir}"/>
 	    <include name="org/xbill/DNS/spi/*.java"/>
 	</javac>
@@ -56,7 +56,7 @@
 			Bundle-SymbolicName: org.xbill.dns
 			Export-Package: org.xbill.DNS;version=${version},org.xbill.DNS.spi;version=${version},org.xbill.DNS.utils;version=${version},org.xbill.DNS.windows;version=${version}
 			Bundle-Vendor: dnsjava.org
-			Bundle-RequiredExecutionEnvironment: J2SE-1.4
+			Bundle-RequiredExecutionEnvironment: J2SE-1.5
 			Import-Package: !org.xbill.DNS*,!sun.*,*
 		</echo>
 		<bndwrap
@@ -107,7 +107,7 @@
     </target>
 
     <target name="compile_tests" depends="compile">
-	<javac destdir="${tests_dir}" debug="true" target="1.4" source="1.4">
+	<javac destdir="${tests_dir}" debug="true" target="1.5" source="1.5">
 	    <src path="${tests_dir}"/>
 	    <exclude name="org/xbill/DNS/DNSSECWithLunaProviderTest**"/>
 	</javac>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>dnsjava</groupId>
     <artifactId>dnsjava</artifactId>
     <packaging>bundle</packaging>
-    <version>2.1.9-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>dnsjava</name>
     <description>dnsjava is an implementation of DNS in Java. It supports all defined record types (including the DNSSEC types), and unknown types. It can be used for queries, zone transfers, and dynamic updates. It includes a cache which can be used by clients, and a minimal implementation of a server. It supports TSIG authenticated messages, partial DNSSEC verification, and EDNS0. </description>
     <organization>
@@ -25,7 +25,7 @@
         <connection>scm:git:https://github.com/dnsjava/dnsjava</connection>
         <developerConnection>scm:git:git@github.com:dnsjava/dnsjava</developerConnection>
         <url>https://github.com/dnsjava/dnsjava</url>
-        <tag>v2.1.8</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>
@@ -36,7 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>iso8859-1</project.build.sourceEncoding>
-        <target.jdk>1.4</target.jdk>
+        <target.jdk>1.5</target.jdk>
     </properties>
 
     <build>
@@ -110,7 +110,7 @@
                         <Import-Package>
                             !org.xbill.DNS*,!sun.*,*
                         </Import-Package>
-                        <Bundle-RequiredExecutionEnvironment>J2SE-1.4</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-RequiredExecutionEnvironment>J2SE-1.5</Bundle-RequiredExecutionEnvironment>
                         <_removeheaders>Bnd-*, Tool, Require-Capability</_removeheaders>
                     </instructions>
                 </configuration>
@@ -210,6 +210,28 @@
                         <configuration>
                             <excludePackageNames>*.tests.*:*.spi.*</excludePackageNames>
                         </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <version>1.17</version>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java15</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>checkjava</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Given we're already using code that requires Java 1.5 and it makes sense to target it now.  Bumped major version because [semver](https://semver.org/).

Also including [animal-sniffer-plugin](https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/) to fail builds if they include code outside the target.