### PR TITLE
Fixes #26 NPE registering NameService

### DIFF
--- a/org/xbill/DNS/spi/DNSJavaNameServiceDescriptor.java
+++ b/org/xbill/DNS/spi/DNSJavaNameServiceDescriptor.java
@@ -12,13 +12,15 @@ import sun.net.spi.nameservice.*;
  * @author Brian Wellington
  * @author Paul Cowan (pwc21@yahoo.com)
  */
-
 public class DNSJavaNameServiceDescriptor implements NameServiceDescriptor {
 
 private static NameService nameService;
 
 static {
 	ClassLoader loader = NameService.class.getClassLoader();
+	if (loader == null) {
+		loader = Thread.currentThread().getContextClassLoader();
+	}
 	nameService = (NameService) Proxy.newProxyInstance(loader,
 			new Class[] { NameService.class },
 			new DNSJavaNameService());


### PR DESCRIPTION
Using `Thread.currentThread().getContextClassLoader()` since that would probably cover the most bases, and is the suggested fix via pmd: https://pmd.github.io/latest/pmd_rules_java_errorprone.html#useproperclassloader