### PR TITLE
Adds japicmp plugin to ensure compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,25 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>clirr-maven-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <!-- JDK9 removed the Nameservice SPI as per bug 8134577. -->
+                    <excludes>org/xbill/DNS/spi/**</excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-compatibility</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,19 +151,27 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.8</version>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>0.14.0</version>
                 <configuration>
-                    <!-- JDK9 removed the Nameservice SPI as per bug 8134577. -->
-                    <excludes>org/xbill/DNS/spi/**</excludes>
+                    <parameter>
+                        <onlyModified>true</onlyModified>
+                        <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                        <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                        <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+                        <excludes>
+                            <!-- JDK9 removed the Nameservice SPI as per bug 8134577. -->
+                            <exclude>org.xbill.DNS.spi</exclude>
+                        </excludes>
+                    </parameter>
                 </configuration>
                 <executions>
                     <execution>
                         <id>check-compatibility</id>
-                        <phase>test</phase>
+                        <phase>package</phase>
                         <goals>
-                            <goal>check</goal>
+                            <goal>cmp</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Per comment in https://github.com/dnsjava/dnsjava/issues/1#issuecomment-493774420
> when I see how much impact the other API changes will have. E.g. adding generics will not necessarily break APIs.

+1 on ensuring APIs don't break.  With this plugin, the build will fail when it detects incompatible API changes, compared to the previous version.  Also gives some insight/sanity checks on non-breaking changes (adding to API, removing method identical to superclass' implementation, etc.).