### PR TITLE
Miscount in Message.sectionToWire

### DIFF
--- a/org/xbill/DNS/Message.java
+++ b/org/xbill/DNS/Message.java
@@ -415,28 +415,28 @@ sectionToWire(DNSOutput out, int section, Compression c,
 	int n = sections[section].size();
 	int pos = out.current();
 	int rendered = 0;
-	int skipped = 0;
+	int count = 0;
 	Record lastrec = null;
 
 	for (int i = 0; i < n; i++) {
 		Record rec = (Record)sections[section].get(i);
 		if (section == Section.ADDITIONAL && rec instanceof OPTRecord) {
-			skipped++;
 			continue;
 		}
 
 		if (lastrec != null && !sameSet(rec, lastrec)) {
 			pos = out.current();
-			rendered = i;
+			rendered = count;
 		}
 		lastrec = rec;
 		rec.toWire(out, section, c);
 		if (out.current() > maxLength) {
 			out.jump(pos);
-			return n - rendered + skipped;
+			return n - rendered;
 		}
+		count++;
 	}
-	return skipped;
+	return n - count;
 }
 
 /* Returns true if the message could be rendered. */

--- a/tests/org/xbill/DNS/MessageTest.java
+++ b/tests/org/xbill/DNS/MessageTest.java
@@ -37,6 +37,7 @@ package org.xbill.DNS;
 import	java.net.InetAddress;
 import	java.net.UnknownHostException;
 import	java.util.Arrays;
+import  java.io.IOException;
 import	junit.framework.Test;
 import	junit.framework.TestCase;
 import	junit.framework.TestSuite;
@@ -105,6 +106,32 @@ public class MessageTest
 	    assertEquals(Opcode.QUERY, h.getOpcode());
 	    assertEquals(true, h.getFlag(Flags.RD));
 	}
+
+        public void test_sectionToWire ()
+          throws IOException
+        {
+            Message m = new Message(4711);
+            Name n2 = Name.fromConstantString("test2.example.");
+            m.addRecord(new TXTRecord(n2, DClass.IN, 86400, "other record"), Section.ADDITIONAL);
+            Name n = Name.fromConstantString("test.example.");
+            m.addRecord(new TXTRecord(n, DClass.IN, 86400, "example text -1-"), Section.ADDITIONAL);
+            m.addRecord(new TXTRecord(n, DClass.IN, 86400, "example text -2-"), Section.ADDITIONAL);
+            m.addRecord(new TXTRecord(n, DClass.IN, 86400, "example text -3-"), Section.ADDITIONAL);
+            m.addRecord(new TXTRecord(n, DClass.IN, 86400, "example text -4-"), Section.ADDITIONAL);
+	    m.addRecord(new OPTRecord(512, 0, 0, 0), Section.ADDITIONAL);
+
+	    for(int i = 5; i < 50; i++)
+               m.addRecord(new TXTRecord(n, DClass.IN, 86400, "example text -" + i + "-"),
+                 Section.ADDITIONAL);
+
+            byte[] binary = m.toWire(512);
+            Message m2 = new Message(binary);
+            assertEquals(2, m2.getHeader().getCount(Section.ADDITIONAL));
+            Record[] records = m2.getSectionArray(Section.ADDITIONAL);
+            assertEquals(2, records.length);
+            assertEquals(TXTRecord.class, records[0].getClass());
+            assertEquals(OPTRecord.class, records[1].getClass());
+        }
 
     }
 


### PR DESCRIPTION
This is the patch for the fix of the issue #60 "Miscount in Message.sectionToWire" in the old SourceForge issue system I opened back then.