### PR TITLE
Fix #44 Prevent SOA serial being set to zero

### DIFF
--- a/src/main/java/org/xbill/DNS/Serial.java
+++ b/src/main/java/org/xbill/DNS/Serial.java
@@ -5,11 +5,10 @@ package org.xbill.DNS;
 /**
  * Helper functions for doing serial arithmetic.  These should be used when
  * setting/checking SOA serial numbers.  SOA serial number arithmetic is
- * defined in RFC 1982.
+ * defined in RFC 1982 and also referenced in RFC 2136.
  *
  * @author Brian Wellington
  */
-
 public final class Serial {
 
 private static final long MAX32 = 0xFFFFFFFFL;
@@ -34,17 +33,14 @@ compare(long serial1, long serial2) {
 	if (serial2 < 0 || serial2 > MAX32)
 		throw new IllegalArgumentException(serial2 + " out of range");
 	long diff = serial1 - serial2;
-	if (diff >= MAX32)
-		diff -= (MAX32 + 1);
-	else if (diff < -MAX32)
-		diff += (MAX32 + 1);
 	return (int)diff;
 }
 
 /**
  * Increments a serial number.  The number is assumed to be a 32 bit unsigned
  * integer stored in a long.  This basically adds 1 and resets the value to
- * 0 if it is 2^32.
+ * 1 if the serial is 2^32.  A zero value is explicitly forbidden as per
+ * RFC 2136 section 4.2 & 7.11.
  * @param serial The serial number
  * @return The incremented serial number
  * @throws IllegalArgumentException serial is out of range
@@ -54,7 +50,7 @@ increment(long serial) {
 	if (serial < 0 || serial > MAX32)
 		throw new IllegalArgumentException(serial + " out of range");
 	if (serial == MAX32)
-		return 0;
+		return 1;
 	return serial + 1;
 }
 

--- a/src/test/java/org/xbill/DNS/SerialTest.java
+++ b/src/test/java/org/xbill/DNS/SerialTest.java
@@ -167,7 +167,7 @@ class SerialTest
     {
 	long arg = 0xFFFFFFFFL;
 	long ret = Serial.increment( arg );
-	assertEquals( 0, ret );
+	assertEquals( 1, ret );
     }
 
     @Test


### PR DESCRIPTION
RFC 2136 seems clear https://tools.ietf.org/html/rfc2136

> 7.11. A zone's SOA SERIAL should never be set to zero (0) ... When incrementing an SOA SERIAL, if the result of the increment is zero (0) (as will be true when wrapping around 2**32), it is necessary to increment it again or set it to one (1).
