### PR TITLE
Remove TokenizerException

### DIFF
--- a/src/main/java/org/xbill/DNS/Master.java
+++ b/src/main/java/org/xbill/DNS/Master.java
@@ -12,7 +12,6 @@ import java.util.*;
  *
  * @author Brian Wellington
  */
-
 public class Master implements AutoCloseable {
 
 private Name origin;
@@ -253,9 +252,6 @@ private Record
 nextGenerated() throws IOException {
 	try {
 		return generator.nextRecord();
-	}
-	catch (Tokenizer.TokenizerException e) {
-		throw st.exception("Parsing $GENERATE: " + e.getBaseMessage());
 	}
 	catch (TextParseException e) {
 		throw st.exception("Parsing $GENERATE: " + e.getMessage());

--- a/src/main/java/org/xbill/DNS/Tokenizer.java
+++ b/src/main/java/org/xbill/DNS/Tokenizer.java
@@ -28,7 +28,6 @@ import org.xbill.DNS.utils.*;
  * @author Brian Wellington
  * @author Bob Halley
  */
-
 public class Tokenizer implements AutoCloseable{
 
 private static String delim = " \t\n;()\"";
@@ -121,21 +120,6 @@ public static class Token {
 	public boolean
 	isEOL() {
 		return (type == EOL || type == EOF);
-	}
-}
-
-static class TokenizerException extends TextParseException {
-	String message;
-
-	public
-	TokenizerException(String filename, int line, String message) {
-		super(filename + ":" + line + ": " + message);
-		this.message = message;
-	}
-
-	public String
-	getBaseMessage() {
-		return message;
 	}
 }
 
@@ -708,7 +692,7 @@ getBase32String(base32 b32) throws IOException {
  */
 public TextParseException
 exception(String s) {
-	return new TokenizerException(filename, line, s);
+	return new TextParseException(filename + ":" + line + ": " + s);
 }
 
 /**

--- a/src/test/java/org/xbill/DNS/MasterTest.java
+++ b/src/test/java/org/xbill/DNS/MasterTest.java
@@ -1,0 +1,74 @@
+package org.xbill.DNS;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MasterTest {
+
+	@Test
+	void nextRecord() throws IOException {
+		Name exampleComName = Name.fromConstantString("example.com.");
+		try (Master master = new Master(MasterTest.class.getResourceAsStream("/zonefileEx1"))) {
+			master.expandGenerate(false);
+			Record rr = master.nextRecord();
+			assertEquals(Type.SOA, rr.getType());
+			rr = master.nextRecord();
+			assertEquals(Type.NS, rr.getType());
+			rr = master.nextRecord();
+			assertEquals(Type.MX, rr.getType());
+
+			rr = master.nextRecord();
+			// test special '@' resolves name correctly
+			assertEquals(exampleComName, rr.getName());
+
+			rr = master.nextRecord();
+			// test relative host become absolute
+			assertEquals(Name.fromConstantString("mail3.example.com."), rr.getAdditionalName());
+
+			rr = master.nextRecord();
+			assertEquals(Type.A, rr.getType());
+
+			rr = master.nextRecord();
+			assertEquals(Type.AAAA, rr.getType());
+
+			rr = master.nextRecord();
+			assertEquals(Type.CNAME, rr.getType());
+
+			rr = master.nextRecord();
+			assertNull(rr);
+			// $GENERATE directive is last in zonefile
+			assertTrue(master.generators().hasNext());
+		}
+	}
+
+	@Test
+	void invalidGenRange() {
+		try (Master master = new Master(MasterTest.class.getResourceAsStream("/zonefileInvalidGenRange"))) {
+			assertThrows(TextParseException.class, master::nextRecord);
+		}
+	}
+
+	@Test
+	void invalidGenType() {
+		try (Master master = new Master(MasterTest.class.getResourceAsStream("/zonefileInvalidGenType"))) {
+			assertThrows(TextParseException.class, master::nextRecord);
+		}
+	}
+
+	@Test
+	void invalidTSIG() {
+		try (Master master = new Master(MasterTest.class.getResourceAsStream("/zonefileInvalidTSIG"))) {
+			assertThrows(TextParseException.class, master::nextRecord);
+		}
+	}
+
+	@Test
+	void invalidOriginNotAbsolute() {
+		assertThrows(RelativeNameException.class, () ->
+			new Master((InputStream) null, Name.fromConstantString("notabsolute")));
+	}
+}

--- a/src/test/resources/zonefileEx1
+++ b/src/test/resources/zonefileEx1
@@ -1,0 +1,11 @@
+$ORIGIN example.com.     ; designates the start of this zone file in the namespace
+$TTL 1h                  ; default expiration time of all resource records without their own TTL value
+example.com.  IN  SOA   ns.example.com. username.example.com. ( 2007120710 1d 2h 4w 1h )
+example.com.  IN  NS    ns                    ; ns.example.com is a nameserver for example.com
+example.com.  IN  MX    10 mail.example.com.  ; mail.example.com is the mailserver for example.com
+@             IN  MX    20 mail2.example.com. ; equivalent to above line, "@" represents zone origin
+@             IN  MX    50 mail3              ; equivalent to above line, but using a relative host name
+example.com.  IN  A     192.0.2.1             ; IPv4 address for example.com
+              IN  AAAA  2001:db8:10::1        ; IPv6 address for example.com
+www           IN  CNAME example.com.          ; www.example.com is an alias for example.com
+$GENERATE 1-3/1 $.0.168.192.in-addr.arpa. PTR host-$.dsl.example.com.

--- a/src/test/resources/zonefileInvalidGenRange
+++ b/src/test/resources/zonefileInvalidGenRange
@@ -1,0 +1,1 @@
+$GENERATE 3-1 $.0.168.192.in-addr.arpa. PTR host-$.dsl.example.com.

--- a/src/test/resources/zonefileInvalidGenType
+++ b/src/test/resources/zonefileInvalidGenType
@@ -1,0 +1,2 @@
+$TTL 1h
+$GENERATE 1-3 example.com.  MX    10 mail.example.com.

--- a/src/test/resources/zonefileInvalidTSIG
+++ b/src/test/resources/zonefileInvalidTSIG
@@ -1,0 +1,1 @@
+monitor.reg.neustar.com. 0  ANY TSIG    hmac-md5.sig-alg.reg.int. 1553302104 300 16 YWDHVhM3MpeTglOvyaj5fA== 27955 NOERROR 0


### PR DESCRIPTION
* Removing the private TokenizerException since it seems to just cause more confusion than help -- seems better to have this consistently under TextParseException.  It's functionality (filename + line number in the message) still exists in the exception method.
* Added an initial MasterTest with example zone files to help sanity check records in zone files