### PR TITLE
addition of EDNS Cookie and TCP Keepalive Options

### DIFF
--- a/src/main/java/org/xbill/DNS/CookieOption.java
+++ b/src/main/java/org/xbill/DNS/CookieOption.java
@@ -1,0 +1,134 @@
+package org.xbill.DNS;
+
+import java.io.IOException;
+
+import org.xbill.DNS.utils.base16;
+
+
+/**
+ * Cookie EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7873
+ *
+ * @see OPTRecord
+ * @author Klaus Malorny
+ */
+public class CookieOption extends EDNSOption {
+
+  /** client cookie */
+  private byte[] clientCookie;
+
+  /** server cookie, may be {@code null} */
+  private byte[] serverCookie;
+
+
+  /**
+   * Default constructor for constructing instance from binary representation.
+   */
+
+  CookieOption() {
+    super(EDNSOption.Code.COOKIE);
+  }
+
+
+  /**
+   * Constructor.
+   *
+   * @param clientCookie   the client cookie, which must consist of eight bytes
+   */
+  public CookieOption(byte[] clientCookie) {
+    this(clientCookie, null);
+  }
+
+
+  /**
+   * Constructor.
+   *
+   * @param clientCookie   the client cookie, which must consist of eight bytes
+   * @param serverCookie   the server cookie, which either must be {@code null}
+   *                       or must consist of 8 to 32 bytes
+   */
+  public CookieOption(byte[] clientCookie, byte[] serverCookie) {
+    this();
+    if (clientCookie == null)
+      throw new IllegalArgumentException("cookie must not be null");
+    if (clientCookie.length != 8)
+      throw new IllegalArgumentException("cookie must consist of eight bytes");
+    this.clientCookie = clientCookie;
+
+    if (serverCookie != null && 
+      (serverCookie.length < 8 || serverCookie.length > 32))
+      throw new IllegalArgumentException (
+        "cookie must consist of 8 to 32 bytes");
+    this.serverCookie = serverCookie;
+  }
+
+
+
+  /**
+   * Returns the client cookie.
+   *
+   * @return    the client cookie
+   */
+  public byte[] getClientCookie() {
+    return clientCookie;
+  }
+
+
+  /**
+   * Returns the server cookie.
+   *
+   * @return   the server cookie, may be {@code null}
+   */
+  public byte[] getServerCookie() {
+    return serverCookie;
+  }
+
+
+  /**
+   * Converts the wire format of an EDNS Option (the option data only) into the type-specific
+   * format.
+   *
+   * @param in The input stream.
+   */
+  @Override
+  void optionFromWire(DNSInput in) throws IOException {
+    int length = in.remaining();
+    if (length < 8)
+      throw new WireParseException("invalid length of client cookie");
+    clientCookie = in.readByteArray(8);
+    if (length > 8) {
+      if (length < 16 || length > 40)
+        throw new WireParseException("invalid length of server cookie");
+      serverCookie = in.readByteArray();
+    }
+  }
+
+
+  /**
+   * Converts an EDNS Option (the type-specific option data only) into wire format.
+   *
+   * @param out The output stream.
+   */
+  @Override
+  void optionToWire(DNSOutput out) {
+    out.writeByteArray(clientCookie);
+    if (serverCookie != null)
+      out.writeByteArray(serverCookie);
+  }
+
+
+  /**
+   * Returns a string representation of the option parameters
+   *
+   * @return    the string representation
+   */
+  @Override
+  String optionToString() {
+    return serverCookie != null ?
+      base16.toString(clientCookie) + " " + base16.toString(serverCookie) :
+      base16.toString(clientCookie);
+  }
+
+}
+
+
+

--- a/src/main/java/org/xbill/DNS/CookieOption.java
+++ b/src/main/java/org/xbill/DNS/CookieOption.java
@@ -1,9 +1,7 @@
 package org.xbill.DNS;
 
 import java.io.IOException;
-
 import org.xbill.DNS.utils.base16;
-
 
 /**
  * Cookie EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7873
@@ -19,69 +17,56 @@ public class CookieOption extends EDNSOption {
   /** server cookie, may be {@code null} */
   private byte[] serverCookie;
 
-
-  /**
-   * Default constructor for constructing instance from binary representation.
-   */
-
+  /** Default constructor for constructing instance from binary representation. */
   CookieOption() {
     super(EDNSOption.Code.COOKIE);
   }
 
-
   /**
    * Constructor.
    *
-   * @param clientCookie   the client cookie, which must consist of eight bytes
+   * @param clientCookie the client cookie, which must consist of eight bytes
    */
   public CookieOption(byte[] clientCookie) {
     this(clientCookie, null);
   }
 
-
   /**
    * Constructor.
    *
-   * @param clientCookie   the client cookie, which must consist of eight bytes
-   * @param serverCookie   the server cookie, which either must be {@code null}
-   *                       or must consist of 8 to 32 bytes
+   * @param clientCookie the client cookie, which must consist of eight bytes
+   * @param serverCookie the server cookie, which either must be {@code null} or must consist of 8
+   *     to 32 bytes
    */
   public CookieOption(byte[] clientCookie, byte[] serverCookie) {
     this();
-    if (clientCookie == null)
-      throw new IllegalArgumentException("cookie must not be null");
+    if (clientCookie == null) throw new IllegalArgumentException("cookie must not be null");
     if (clientCookie.length != 8)
       throw new IllegalArgumentException("cookie must consist of eight bytes");
     this.clientCookie = clientCookie;
 
-    if (serverCookie != null && 
-      (serverCookie.length < 8 || serverCookie.length > 32))
-      throw new IllegalArgumentException (
-        "cookie must consist of 8 to 32 bytes");
+    if (serverCookie != null && (serverCookie.length < 8 || serverCookie.length > 32))
+      throw new IllegalArgumentException("cookie must consist of 8 to 32 bytes");
     this.serverCookie = serverCookie;
   }
-
-
 
   /**
    * Returns the client cookie.
    *
-   * @return    the client cookie
+   * @return the client cookie
    */
   public byte[] getClientCookie() {
     return clientCookie;
   }
 
-
   /**
    * Returns the server cookie.
    *
-   * @return   the server cookie, may be {@code null}
+   * @return the server cookie, may be {@code null}
    */
   public byte[] getServerCookie() {
     return serverCookie;
   }
-
 
   /**
    * Converts the wire format of an EDNS Option (the option data only) into the type-specific
@@ -92,8 +77,7 @@ public class CookieOption extends EDNSOption {
   @Override
   void optionFromWire(DNSInput in) throws IOException {
     int length = in.remaining();
-    if (length < 8)
-      throw new WireParseException("invalid length of client cookie");
+    if (length < 8) throw new WireParseException("invalid length of client cookie");
     clientCookie = in.readByteArray(8);
     if (length > 8) {
       if (length < 16 || length > 40)
@@ -101,7 +85,6 @@ public class CookieOption extends EDNSOption {
       serverCookie = in.readByteArray();
     }
   }
-
 
   /**
    * Converts an EDNS Option (the type-specific option data only) into wire format.
@@ -111,24 +94,18 @@ public class CookieOption extends EDNSOption {
   @Override
   void optionToWire(DNSOutput out) {
     out.writeByteArray(clientCookie);
-    if (serverCookie != null)
-      out.writeByteArray(serverCookie);
+    if (serverCookie != null) out.writeByteArray(serverCookie);
   }
-
 
   /**
    * Returns a string representation of the option parameters
    *
-   * @return    the string representation
+   * @return the string representation
    */
   @Override
   String optionToString() {
-    return serverCookie != null ?
-      base16.toString(clientCookie) + " " + base16.toString(serverCookie) :
-      base16.toString(clientCookie);
+    return serverCookie != null
+        ? base16.toString(clientCookie) + " " + base16.toString(serverCookie)
+        : base16.toString(clientCookie);
   }
-
 }
-
-
-

--- a/src/main/java/org/xbill/DNS/EDNSOption.java
+++ b/src/main/java/org/xbill/DNS/EDNSOption.java
@@ -22,6 +22,12 @@ public abstract class EDNSOption {
     /** Client Subnet, defined in draft-vandergaast-edns-client-subnet-02 */
     public static final int CLIENT_SUBNET = 8;
 
+    /** Cookie, RFC 7873 */
+    public static final int COOKIE = 10;
+
+    /** TCP Keepalive, RFC 7828 */
+    public static final int TCP_KEEPALIVE = 11;
+
     private static Mnemonic codes = new Mnemonic("EDNS Option Codes", Mnemonic.CASE_UPPER);
 
     static {
@@ -31,6 +37,8 @@ public abstract class EDNSOption {
 
       codes.add(NSID, "NSID");
       codes.add(CLIENT_SUBNET, "CLIENT_SUBNET");
+      codes.add(COOKIE, "COOKIE");
+      codes.add(TCP_KEEPALIVE, "TCP_KEEPALIVE");
     }
 
     /** Converts an EDNS Option Code into its textual representation */
@@ -120,6 +128,9 @@ public abstract class EDNSOption {
         break;
       case Code.CLIENT_SUBNET:
         option = new ClientSubnetOption();
+        break;
+      case Code.COOKIE:
+        option = new CookieOption();
         break;
       default:
         option = new GenericEDNSOption(code);

--- a/src/main/java/org/xbill/DNS/EDNSOption.java
+++ b/src/main/java/org/xbill/DNS/EDNSOption.java
@@ -132,6 +132,9 @@ public abstract class EDNSOption {
       case Code.COOKIE:
         option = new CookieOption();
         break;
+      case Code.TCP_KEEPALIVE:
+        option = new TcpKeepaliveOption();
+        break;
       default:
         option = new GenericEDNSOption(code);
         break;

--- a/src/main/java/org/xbill/DNS/Rcode.java
+++ b/src/main/java/org/xbill/DNS/Rcode.java
@@ -66,6 +66,19 @@ public final class Rcode {
   /** The mode is invalid (TKEY extended error) */
   public static final int BADMODE = 19;
 
+  /** Duplicate key name (TKEY extended error) */
+  public static final int BADNAME = 20;
+
+  /** Algorithm not supported (TKEY extended error) */
+  public static final int BADALG = 21;
+
+  /** Bad truncation (RFC 4635) */
+  public static final int BADTRUNC = 22;
+
+  /** Bad or missing server cookie (RFC 7873) */
+  public static final int BADCOOKIE = 23;
+
+
   static {
     rcodes.setMaximum(0xFFF);
     rcodes.setPrefix("RESERVED");
@@ -84,6 +97,10 @@ public final class Rcode {
     rcodes.add(NOTAUTH, "NOTAUTH");
     rcodes.add(NOTZONE, "NOTZONE");
     rcodes.add(BADVERS, "BADVERS");
+    rcodes.add(BADMODE, "BADMODE");
+    rcodes.add(BADNAME, "BADNAME");
+    rcodes.add(BADALG, "BADALG");
+    rcodes.add(BADCOOKIE, "BADCOOKIE");
 
     tsigrcodes.setMaximum(0xFFFF);
     tsigrcodes.setPrefix("RESERVED");
@@ -93,7 +110,6 @@ public final class Rcode {
     tsigrcodes.add(BADSIG, "BADSIG");
     tsigrcodes.add(BADKEY, "BADKEY");
     tsigrcodes.add(BADTIME, "BADTIME");
-    tsigrcodes.add(BADMODE, "BADMODE");
   }
 
   private Rcode() {}

--- a/src/main/java/org/xbill/DNS/Rcode.java
+++ b/src/main/java/org/xbill/DNS/Rcode.java
@@ -78,7 +78,6 @@ public final class Rcode {
   /** Bad or missing server cookie (RFC 7873) */
   public static final int BADCOOKIE = 23;
 
-
   static {
     rcodes.setMaximum(0xFFF);
     rcodes.setPrefix("RESERVED");

--- a/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
+++ b/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
@@ -1,9 +1,9 @@
 package org.xbill.DNS;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.time.Duration;
 
 /**
  * TCP Keepalive EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7828
@@ -38,19 +38,18 @@ public class TcpKeepaliveOption extends EDNSOption {
   }
 
   /**
-   * Constructor for an option with a given timeout. As the timeout has a coarser
-   * granularity than the {@link Duration} class, values are rounded down.
+   * Constructor for an option with a given timeout. As the timeout has a coarser granularity than
+   * the {@link Duration} class, values are rounded down.
    *
-   * @param t the timeout time, must not be negative and must be lower than
-   * 6553.5 seconds
+   * @param t the timeout time, must not be negative and must be lower than 6553.5 seconds
    */
   public TcpKeepaliveOption(Duration t) {
     super(EDNSOption.Code.TCP_KEEPALIVE);
     if (t.isNegative() || t.compareTo(UPPER_LIMIT) >= 0)
-      throw new IllegalArgumentException("timeout must be between 0 and 6553.6 seconds (exclusively)");
-    timeout = OptionalInt.of((int)t.toMillis()/100);
+      throw new IllegalArgumentException(
+          "timeout must be between 0 and 6553.6 seconds (exclusively)");
+    timeout = OptionalInt.of((int) t.toMillis() / 100);
   }
-
 
   /**
    * Returns the timeout.
@@ -67,9 +66,10 @@ public class TcpKeepaliveOption extends EDNSOption {
    * @reutrn the timeout
    */
   public Optional<Duration> getTimeoutDuration() {
-    return timeout.isPresent() ? Optional.of(Duration.ofMillis(timeout.getAsInt() * 100)) : Optional.empty();
+    return timeout.isPresent()
+        ? Optional.of(Duration.ofMillis(timeout.getAsInt() * 100))
+        : Optional.empty();
   }
-
 
   /**
    * Converts the wire format of an EDNS Option (the option data only) into the type-specific

--- a/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
+++ b/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
@@ -2,7 +2,6 @@ package org.xbill.DNS;
 
 import java.io.IOException;
 
-
 /**
  * TCP Keepalive EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7828
  *
@@ -17,21 +16,16 @@ public class TcpKeepaliveOption extends EDNSOption {
   /** the timeout in 100ms units */
   private int timeout;
 
-
-  /**
-   * Constructor for an option with no timeout
-   */
+  /** Constructor for an option with no timeout */
   public TcpKeepaliveOption() {
     super(EDNSOption.Code.TCP_KEEPALIVE);
     hasTimeout = false;
   }
 
-
   /**
    * Constructor for an option with a given timeout.
    *
-   * @param t   the timeout time in 100ms units, may not be negative or
-   *            larger than 65535
+   * @param t the timeout time in 100ms units, may not be negative or larger than 65535
    */
   public TcpKeepaliveOption(int t) {
     super(EDNSOption.Code.TCP_KEEPALIVE);
@@ -41,29 +35,24 @@ public class TcpKeepaliveOption extends EDNSOption {
     timeout = t;
   }
 
-
   /**
    * Returns whether the option contains a timeout.
    *
-   * @return   {@code true} if the option contains a timeout
+   * @return {@code true} if the option contains a timeout
    */
   public boolean hasTimeout() {
     return hasTimeout;
   }
 
-
   /**
    * Returns the timeout.
    *
-   * @return    the timeout in 100ms units
+   * @return the timeout in 100ms units
    */
-  public int getTimeout()
-  {
-    if (!hasTimeout)
-      throw new IllegalStateException("option does not have the timeout set");
+  public int getTimeout() {
+    if (!hasTimeout) throw new IllegalStateException("option does not have the timeout set");
     return timeout;
   }
-
 
   /**
    * Converts the wire format of an EDNS Option (the option data only) into the type-specific
@@ -84,11 +73,10 @@ public class TcpKeepaliveOption extends EDNSOption {
         timeout = in.readU16();
         break;
       default:
-        throw new WireParseException("invalid length (" + length + 
-          ") of the data in the edns_tcp_keepalive option");
+        throw new WireParseException(
+            "invalid length (" + length + ") of the data in the edns_tcp_keepalive option");
     }
   }
-
 
   /**
    * Converts an EDNS Option (the type-specific option data only) into wire format.
@@ -97,21 +85,16 @@ public class TcpKeepaliveOption extends EDNSOption {
    */
   @Override
   void optionToWire(DNSOutput out) {
-    if (hasTimeout)
-      out.writeU16(timeout);
+    if (hasTimeout) out.writeU16(timeout);
   }
-
 
   /**
    * Returns a string representation of the option parameters.
    *
-   * @return    the string representation
+   * @return the string representation
    */
   @Override
   String optionToString() {
-    return hasTimeout ? String.valueOf (timeout) : "-";
+    return hasTimeout ? String.valueOf(timeout) : "-";
   }
-
 }
-
-

--- a/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
+++ b/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
@@ -1,6 +1,9 @@
 package org.xbill.DNS;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.time.Duration;
 
 /**
  * TCP Keepalive EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7828
@@ -10,16 +13,16 @@ import java.io.IOException;
  */
 public class TcpKeepaliveOption extends EDNSOption {
 
-  /** flag whether the timeout has been provided */
-  private boolean hasTimeout;
+  /** the timeout */
+  private OptionalInt timeout;
 
-  /** the timeout in 100ms units */
-  private int timeout;
+  /** upper limit of the duration (exclusive) */
+  private static final Duration UPPER_LIMIT = Duration.ofMillis(6553600);
 
   /** Constructor for an option with no timeout */
   public TcpKeepaliveOption() {
     super(EDNSOption.Code.TCP_KEEPALIVE);
-    hasTimeout = false;
+    timeout = OptionalInt.empty();
   }
 
   /**
@@ -31,28 +34,42 @@ public class TcpKeepaliveOption extends EDNSOption {
     super(EDNSOption.Code.TCP_KEEPALIVE);
     if (t < 0 || t > 65535)
       throw new IllegalArgumentException("timeout must be betwee 0 and 65535");
-    hasTimeout = true;
-    timeout = t;
+    timeout = OptionalInt.of(t);
   }
 
   /**
-   * Returns whether the option contains a timeout.
+   * Constructor for an option with a given timeout. As the timeout has a coarser
+   * granularity than the {@link Duration} class, values are rounded down.
    *
-   * @return {@code true} if the option contains a timeout
+   * @param t the timeout time, must not be negative and must be lower than
+   * 6553.5 seconds
    */
-  public boolean hasTimeout() {
-    return hasTimeout;
+  public TcpKeepaliveOption(Duration t) {
+    super(EDNSOption.Code.TCP_KEEPALIVE);
+    if (t.isNegative() || t.compareTo(UPPER_LIMIT) >= 0)
+      throw new IllegalArgumentException("timeout must be between 0 and 6553.6 seconds (exclusively)");
+    timeout = OptionalInt.of((int)t.toMillis()/100);
   }
+
 
   /**
    * Returns the timeout.
    *
    * @return the timeout in 100ms units
    */
-  public int getTimeout() {
-    if (!hasTimeout) throw new IllegalStateException("option does not have the timeout set");
+  public OptionalInt getTimeout() {
     return timeout;
   }
+
+  /**
+   * Returns the timeout as a {@link Duration}.
+   *
+   * @reutrn the timeout
+   */
+  public Optional<Duration> getTimeoutDuration() {
+    return timeout.isPresent() ? Optional.of(Duration.ofMillis(timeout.getAsInt() * 100)) : Optional.empty();
+  }
+
 
   /**
    * Converts the wire format of an EDNS Option (the option data only) into the type-specific
@@ -66,11 +83,10 @@ public class TcpKeepaliveOption extends EDNSOption {
 
     switch (length) {
       case 0:
-        hasTimeout = false;
+        timeout = OptionalInt.empty();
         break;
       case 2:
-        hasTimeout = true;
-        timeout = in.readU16();
+        timeout = OptionalInt.of(in.readU16());
         break;
       default:
         throw new WireParseException(
@@ -85,7 +101,7 @@ public class TcpKeepaliveOption extends EDNSOption {
    */
   @Override
   void optionToWire(DNSOutput out) {
-    if (hasTimeout) out.writeU16(timeout);
+    if (timeout.isPresent()) out.writeU16(timeout.getAsInt());
   }
 
   /**
@@ -95,6 +111,6 @@ public class TcpKeepaliveOption extends EDNSOption {
    */
   @Override
   String optionToString() {
-    return hasTimeout ? String.valueOf(timeout) : "-";
+    return timeout.isPresent() ? String.valueOf(timeout.getAsInt()) : "-";
   }
 }

--- a/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
+++ b/src/main/java/org/xbill/DNS/TcpKeepaliveOption.java
@@ -1,0 +1,117 @@
+package org.xbill.DNS;
+
+import java.io.IOException;
+
+
+/**
+ * TCP Keepalive EDNS0 Option, as defined in https://tools.ietf.org/html/rfc7828
+ *
+ * @see OPTRecord
+ * @author Klaus Malorny
+ */
+public class TcpKeepaliveOption extends EDNSOption {
+
+  /** flag whether the timeout has been provided */
+  private boolean hasTimeout;
+
+  /** the timeout in 100ms units */
+  private int timeout;
+
+
+  /**
+   * Constructor for an option with no timeout
+   */
+  public TcpKeepaliveOption() {
+    super(EDNSOption.Code.TCP_KEEPALIVE);
+    hasTimeout = false;
+  }
+
+
+  /**
+   * Constructor for an option with a given timeout.
+   *
+   * @param t   the timeout time in 100ms units, may not be negative or
+   *            larger than 65535
+   */
+  public TcpKeepaliveOption(int t) {
+    super(EDNSOption.Code.TCP_KEEPALIVE);
+    if (t < 0 || t > 65535)
+      throw new IllegalArgumentException("timeout must be betwee 0 and 65535");
+    hasTimeout = true;
+    timeout = t;
+  }
+
+
+  /**
+   * Returns whether the option contains a timeout.
+   *
+   * @return   {@code true} if the option contains a timeout
+   */
+  public boolean hasTimeout() {
+    return hasTimeout;
+  }
+
+
+  /**
+   * Returns the timeout.
+   *
+   * @return    the timeout in 100ms units
+   */
+  public int getTimeout()
+  {
+    if (!hasTimeout)
+      throw new IllegalStateException("option does not have the timeout set");
+    return timeout;
+  }
+
+
+  /**
+   * Converts the wire format of an EDNS Option (the option data only) into the type-specific
+   * format.
+   *
+   * @param in The input stream.
+   */
+  @Override
+  void optionFromWire(DNSInput in) throws IOException {
+    int length = in.remaining();
+
+    switch (length) {
+      case 0:
+        hasTimeout = false;
+        break;
+      case 2:
+        hasTimeout = true;
+        timeout = in.readU16();
+        break;
+      default:
+        throw new WireParseException("invalid length (" + length + 
+          ") of the data in the edns_tcp_keepalive option");
+    }
+  }
+
+
+  /**
+   * Converts an EDNS Option (the type-specific option data only) into wire format.
+   *
+   * @param out The output stream.
+   */
+  @Override
+  void optionToWire(DNSOutput out) {
+    if (hasTimeout)
+      out.writeU16(timeout);
+  }
+
+
+  /**
+   * Returns a string representation of the option parameters.
+   *
+   * @return    the string representation
+   */
+  @Override
+  String optionToString() {
+    return hasTimeout ? String.valueOf (timeout) : "-";
+  }
+
+}
+
+

--- a/src/test/java/org/xbill/DNS/CookieOptionTest.java
+++ b/src/test/java/org/xbill/DNS/CookieOptionTest.java
@@ -1,0 +1,105 @@
+package org.xbill.DNS;
+
+import java.util.Optional;
+
+import java.time.Duration;
+
+import java.io.IOException;
+
+import org.xbill.DNS.utils.base16;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CookieOptionTest {
+
+
+  @Test
+  void constructorTests() {
+    byte[] sevenBytes = base16.fromString("20212223242526");
+    byte[] eightBytes = base16.fromString("3031323334353637");
+    byte[] eightBytes2 = base16.fromString("A0A1A2A3A4A5A6A7");
+    byte[] nineBytes = base16.fromString("404142434445565748");
+    byte[] thirtyTwoBytes = base16.fromString(
+     "505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F");
+    byte[] thirtyThreeBytes = base16.fromString(
+     "707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F90");
+
+    CookieOption option = new CookieOption(eightBytes);
+    assertArrayEquals(eightBytes, option.getClientCookie());
+    assertFalse(option.getServerCookie().isPresent());
+    new CookieOption(eightBytes, Optional.empty());
+
+    option = new CookieOption(eightBytes, Optional.empty());
+    assertArrayEquals(eightBytes, option.getClientCookie());
+    assertFalse(option.getServerCookie().isPresent());
+
+    option = new CookieOption(eightBytes, Optional.of(eightBytes2));
+    Optional<byte[]> serverCookie = option.getServerCookie();
+    assertTrue(serverCookie.isPresent());
+    assertArrayEquals(eightBytes2, serverCookie.get());
+
+    option = new CookieOption(eightBytes, Optional.of(thirtyTwoBytes));
+    serverCookie = option.getServerCookie();
+    assertTrue(serverCookie.isPresent());
+    assertArrayEquals(thirtyTwoBytes, serverCookie.get());
+
+    assertThrows(IllegalArgumentException.class, () -> new CookieOption(sevenBytes));
+    assertThrows(IllegalArgumentException.class, () -> new CookieOption(nineBytes));
+    assertThrows(IllegalArgumentException.class, () -> new CookieOption(eightBytes, Optional.of (sevenBytes)));
+    assertThrows(IllegalArgumentException.class, () -> new CookieOption(eightBytes, Optional.of (thirtyThreeBytes)));
+  }
+
+  @Test
+  void wireTests() throws IOException {
+    byte[] clientOnlyCookieOption = base16.fromString("000A00081011121314151617");
+    byte[] clientCookie1 = base16.fromString("1011121314151617");
+    byte[] clientServerCookieOption = base16.fromString("000A0012202122232425262730313233343536373839");
+    byte[] clientCookie2 = base16.fromString("2021222324252627");
+    byte[] serverCookie2 = base16.fromString("30313233343536373839");
+    byte[] validLength1 = base16.fromString("000A0010000102030405060708090A0B0C0D0E0F");
+    byte[] validLength2 = base16.fromString("000A0028000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627");
+    byte[] brokenLength1 = base16.fromString("000A000700010203040506");
+    byte[] brokenLength2 = base16.fromString("000A000C000102030405060708090A0B");
+    byte[] brokenLength3 = base16.fromString("000A000F000102030405060708090A0B0C0D0E");
+    byte[] brokenLength4 = base16.fromString("000A0029000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728");
+
+    EDNSOption option = EDNSOption.fromWire(clientOnlyCookieOption);
+    assertNotNull(option);
+    assertEquals(CookieOption.class, option.getClass());
+    CookieOption cookieOption = (CookieOption) option;
+    assertArrayEquals(clientCookie1, cookieOption.getClientCookie());
+    assertFalse(cookieOption.getServerCookie().isPresent());
+
+    option = EDNSOption.fromWire(clientServerCookieOption);
+    assertNotNull(option);
+    assertEquals(CookieOption.class, option.getClass());
+    cookieOption = (CookieOption) option;
+    assertArrayEquals(clientCookie2, cookieOption.getClientCookie());
+    assertTrue(cookieOption.getServerCookie().isPresent());
+    assertArrayEquals(serverCookie2, cookieOption.getServerCookie().get());
+
+    EDNSOption.fromWire(validLength1);
+    EDNSOption.fromWire(validLength2);
+
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLength1));
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLength2));
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLength3));
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLength4));
+
+    cookieOption = new CookieOption(clientCookie1);
+    assertArrayEquals(clientOnlyCookieOption, cookieOption.toWire());
+
+    cookieOption = new CookieOption(clientCookie2, Optional.of(serverCookie2));
+    assertArrayEquals(clientServerCookieOption, cookieOption.toWire());
+  }
+}
+

--- a/src/test/java/org/xbill/DNS/CookieOptionTest.java
+++ b/src/test/java/org/xbill/DNS/CookieOptionTest.java
@@ -1,26 +1,18 @@
 package org.xbill.DNS;
 
-import java.util.Optional;
-
-import java.time.Duration;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
 import org.xbill.DNS.utils.base16;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 class CookieOptionTest {
-
 
   @Test
   void constructorTests() {
@@ -28,10 +20,10 @@ class CookieOptionTest {
     byte[] eightBytes = base16.fromString("3031323334353637");
     byte[] eightBytes2 = base16.fromString("A0A1A2A3A4A5A6A7");
     byte[] nineBytes = base16.fromString("404142434445565748");
-    byte[] thirtyTwoBytes = base16.fromString(
-     "505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F");
-    byte[] thirtyThreeBytes = base16.fromString(
-     "707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F90");
+    byte[] thirtyTwoBytes =
+        base16.fromString("505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F");
+    byte[] thirtyThreeBytes =
+        base16.fromString("707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F90");
 
     CookieOption option = new CookieOption(eightBytes);
     assertArrayEquals(eightBytes, option.getClientCookie());
@@ -54,23 +46,32 @@ class CookieOptionTest {
 
     assertThrows(IllegalArgumentException.class, () -> new CookieOption(sevenBytes));
     assertThrows(IllegalArgumentException.class, () -> new CookieOption(nineBytes));
-    assertThrows(IllegalArgumentException.class, () -> new CookieOption(eightBytes, Optional.of (sevenBytes)));
-    assertThrows(IllegalArgumentException.class, () -> new CookieOption(eightBytes, Optional.of (thirtyThreeBytes)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CookieOption(eightBytes, Optional.of(sevenBytes)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CookieOption(eightBytes, Optional.of(thirtyThreeBytes)));
   }
 
   @Test
   void wireTests() throws IOException {
     byte[] clientOnlyCookieOption = base16.fromString("000A00081011121314151617");
     byte[] clientCookie1 = base16.fromString("1011121314151617");
-    byte[] clientServerCookieOption = base16.fromString("000A0012202122232425262730313233343536373839");
+    byte[] clientServerCookieOption =
+        base16.fromString("000A0012202122232425262730313233343536373839");
     byte[] clientCookie2 = base16.fromString("2021222324252627");
     byte[] serverCookie2 = base16.fromString("30313233343536373839");
     byte[] validLength1 = base16.fromString("000A0010000102030405060708090A0B0C0D0E0F");
-    byte[] validLength2 = base16.fromString("000A0028000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627");
+    byte[] validLength2 =
+        base16.fromString(
+            "000A0028000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627");
     byte[] brokenLength1 = base16.fromString("000A000700010203040506");
     byte[] brokenLength2 = base16.fromString("000A000C000102030405060708090A0B");
     byte[] brokenLength3 = base16.fromString("000A000F000102030405060708090A0B0C0D0E");
-    byte[] brokenLength4 = base16.fromString("000A0029000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728");
+    byte[] brokenLength4 =
+        base16.fromString(
+            "000A0029000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728");
 
     EDNSOption option = EDNSOption.fromWire(clientOnlyCookieOption);
     assertNotNull(option);
@@ -102,4 +103,3 @@ class CookieOptionTest {
     assertArrayEquals(clientServerCookieOption, cookieOption.toWire());
   }
 }
-

--- a/src/test/java/org/xbill/DNS/RcodeTest.java
+++ b/src/test/java/org/xbill/DNS/RcodeTest.java
@@ -50,7 +50,7 @@ class RcodeTest {
     assertEquals("NOTIMP", Rcode.string(Rcode.NOTIMP));
 
     // one that doesn't exist
-    assertTrue(Rcode.string(20).startsWith("RESERVED"));
+    assertTrue(Rcode.string(30).startsWith("RESERVED"));
 
     assertThrows(IllegalArgumentException.class, () -> Rcode.string(-1));
 
@@ -64,7 +64,7 @@ class RcodeTest {
     assertEquals("BADSIG", Rcode.TSIGstring(Rcode.BADSIG));
 
     // one that doesn't exist
-    assertTrue(Rcode.TSIGstring(20).startsWith("RESERVED"));
+    assertTrue(Rcode.TSIGstring(30).startsWith("RESERVED"));
 
     assertThrows(IllegalArgumentException.class, () -> Rcode.TSIGstring(-1));
 

--- a/src/test/java/org/xbill/DNS/TcpKeepaliveOptionTest.java
+++ b/src/test/java/org/xbill/DNS/TcpKeepaliveOptionTest.java
@@ -1,21 +1,15 @@
 package org.xbill.DNS;
 
-import java.time.Duration;
-
-import java.io.IOException;
-
-import org.xbill.DNS.utils.base16;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.io.IOException;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.xbill.DNS.utils.base16;
 
 class TcpKeepaliveOptionTest {
 
@@ -26,10 +20,19 @@ class TcpKeepaliveOptionTest {
     assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(-1));
     assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(65536));
     assertEquals(200, new TcpKeepaliveOption(Duration.ofSeconds(20)).getTimeout().getAsInt());
-    assertEquals(Duration.ofSeconds(30), new TcpKeepaliveOption(Duration.ofSeconds(30)).getTimeoutDuration().get());
-    assertEquals(15, new TcpKeepaliveOption(Duration.ofSeconds (1, 599_999_999)).getTimeout().getAsInt());  // round down test
-    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(Duration.ofMillis(-1)));
-    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(Duration.ofHours(2))); // 2h > 6553.5 seconds
+    assertEquals(
+        Duration.ofSeconds(30),
+        new TcpKeepaliveOption(Duration.ofSeconds(30)).getTimeoutDuration().get());
+    assertEquals(
+        15,
+        new TcpKeepaliveOption(Duration.ofSeconds(1, 599_999_999))
+            .getTimeout()
+            .getAsInt()); // round down test
+    assertThrows(
+        IllegalArgumentException.class, () -> new TcpKeepaliveOption(Duration.ofMillis(-1)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new TcpKeepaliveOption(Duration.ofHours(2))); // 2h > 6553.5 seconds
   }
 
   @Test
@@ -43,17 +46,17 @@ class TcpKeepaliveOptionTest {
     EDNSOption option = EDNSOption.fromWire(emptyTimeout);
     assertNotNull(option);
     assertEquals(TcpKeepaliveOption.class, option.getClass());
-    assertFalse(((TcpKeepaliveOption)option).getTimeout().isPresent());
+    assertFalse(((TcpKeepaliveOption) option).getTimeout().isPresent());
 
     option = EDNSOption.fromWire(thirtySecsTimeout);
     assertNotNull(option);
     assertEquals(TcpKeepaliveOption.class, option.getClass());
-    assertEquals(300, ((TcpKeepaliveOption)option).getTimeout().getAsInt());
+    assertEquals(300, ((TcpKeepaliveOption) option).getTimeout().getAsInt());
 
     option = EDNSOption.fromWire(maxTimeout);
     assertNotNull(option);
     assertEquals(TcpKeepaliveOption.class, option.getClass());
-    assertEquals(65535, ((TcpKeepaliveOption)option).getTimeout().getAsInt());
+    assertEquals(65535, ((TcpKeepaliveOption) option).getTimeout().getAsInt());
 
     assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLengthTimeout1));
     assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLengthTimeout2));
@@ -63,4 +66,3 @@ class TcpKeepaliveOptionTest {
     assertArrayEquals(maxTimeout, new TcpKeepaliveOption(65535).toWire());
   }
 }
-

--- a/src/test/java/org/xbill/DNS/TcpKeepaliveOptionTest.java
+++ b/src/test/java/org/xbill/DNS/TcpKeepaliveOptionTest.java
@@ -1,0 +1,66 @@
+package org.xbill.DNS;
+
+import java.time.Duration;
+
+import java.io.IOException;
+
+import org.xbill.DNS.utils.base16;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TcpKeepaliveOptionTest {
+
+  @Test
+  void constructorTests() {
+    assertFalse(new TcpKeepaliveOption().getTimeout().isPresent());
+    assertEquals(100, new TcpKeepaliveOption(100).getTimeout().getAsInt());
+    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(-1));
+    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(65536));
+    assertEquals(200, new TcpKeepaliveOption(Duration.ofSeconds(20)).getTimeout().getAsInt());
+    assertEquals(Duration.ofSeconds(30), new TcpKeepaliveOption(Duration.ofSeconds(30)).getTimeoutDuration().get());
+    assertEquals(15, new TcpKeepaliveOption(Duration.ofSeconds (1, 599_999_999)).getTimeout().getAsInt());  // round down test
+    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(Duration.ofMillis(-1)));
+    assertThrows(IllegalArgumentException.class, () -> new TcpKeepaliveOption(Duration.ofHours(2))); // 2h > 6553.5 seconds
+  }
+
+  @Test
+  void wireTests() throws IOException {
+    byte[] emptyTimeout = base16.fromString("000B0000");
+    byte[] thirtySecsTimeout = base16.fromString("000B0002012C");
+    byte[] maxTimeout = base16.fromString("000B0002FFFF");
+    byte[] brokenLengthTimeout1 = base16.fromString("000B0001AA");
+    byte[] brokenLengthTimeout2 = base16.fromString("000B0005AABBCCDDEE");
+
+    EDNSOption option = EDNSOption.fromWire(emptyTimeout);
+    assertNotNull(option);
+    assertEquals(TcpKeepaliveOption.class, option.getClass());
+    assertFalse(((TcpKeepaliveOption)option).getTimeout().isPresent());
+
+    option = EDNSOption.fromWire(thirtySecsTimeout);
+    assertNotNull(option);
+    assertEquals(TcpKeepaliveOption.class, option.getClass());
+    assertEquals(300, ((TcpKeepaliveOption)option).getTimeout().getAsInt());
+
+    option = EDNSOption.fromWire(maxTimeout);
+    assertNotNull(option);
+    assertEquals(TcpKeepaliveOption.class, option.getClass());
+    assertEquals(65535, ((TcpKeepaliveOption)option).getTimeout().getAsInt());
+
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLengthTimeout1));
+    assertThrows(WireParseException.class, () -> EDNSOption.fromWire(brokenLengthTimeout2));
+
+    assertArrayEquals(emptyTimeout, new TcpKeepaliveOption().toWire());
+    assertArrayEquals(thirtySecsTimeout, new TcpKeepaliveOption(300).toWire());
+    assertArrayEquals(maxTimeout, new TcpKeepaliveOption(65535).toWire());
+  }
+}
+


### PR DESCRIPTION
I have implemented EDNS options for DNS Cookies (RFC 7873) and for TCP Keepalive (RFC 7828). When adding the BADCOOKIE RCODE to the Rcode class, I discovered that for TKEY, two RCODEs were missing and and another was added to the tsigrcodes instance, which is IMHO wrong. I moved the latter to the regular rcodes instance. As this is fully included into the tsigrcodes instance, it should not break any existing code. Finally, I fixed one test class, as the RCODE 20 is no longer a "reserved" value, but actually used.

It would be nice if you could eventually merge my additions and changes into the trunk. In case of any questions or problems, feel free to contact me.