### PR TITLE
Expose control over Lookup result ordering

### DIFF
--- a/src/main/java/org/xbill/DNS/Lookup.java
+++ b/src/main/java/org/xbill/DNS/Lookup.java
@@ -56,6 +56,7 @@ public final class Lookup {
   private boolean timedout;
   private boolean nametoolong;
   private boolean referral;
+  private boolean cycleResults = true;
 
   private static final Name[] noAliases = new Name[0];
 
@@ -369,6 +370,16 @@ public final class Lookup {
     this.credibility = credibility;
   }
 
+  /**
+   * Controls the behavior of is results being returned from the cache should be cycled in a
+   * round-robin style (true) or if the raw lookup results should be returned (false)
+   *
+   * @param cycleResults The desired behavior of the order of the results
+   */
+  public void setCycleResults(boolean cycleResults) {
+    this.cycleResults = cycleResults;
+  }
+
   private void follow(Name name, Name oldname) {
     foundAlias = true;
     badresponse = false;
@@ -396,7 +407,7 @@ public final class Lookup {
       List<Record> l = new ArrayList<>();
 
       for (RRset<?> set : rrsets) {
-        l.addAll(set.rrs());
+        l.addAll(set.rrs(cycleResults));
       }
 
       result = SUCCESSFUL;


### PR DESCRIPTION
* The implementation of Lookup always used the default behavior of
  the RRSet results which performs a round-robin rotation when
  returning results. We have a use case where we want to control
  the rotation of the list from the DNS server side without a second
  layer potentially rotating the results when retrieved from a cache.
* Exposed a new field on Lookup.java to allow the static ordering to
  be returned, while defaulting to the previous behavior.