### PR TITLE
Only select for tcp write when there is something to write

### DIFF
--- a/src/main/java/org/xbill/DNS/NioTcpClient.java
+++ b/src/main/java/org/xbill/DNS/NioTcpClient.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.time.Duration;
@@ -24,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @UtilityClass
 final class NioTcpClient extends Client {
-  private static Queue<ChannelState> registrationQueue;
   private static Map<ChannelKey, ChannelState> channelMap;
   private static volatile boolean run;
 
@@ -34,24 +32,9 @@ final class NioTcpClient extends Client {
     }
 
     run = true;
-    registrationQueue = new ConcurrentLinkedQueue<>();
     channelMap = new ConcurrentHashMap<>();
-    addSelectorTimeoutTask(NioTcpClient::processPendingRegistrations);
     addSelectorTimeoutTask(NioTcpClient::checkTransactionTimeouts);
     start();
-  }
-
-  private static void processPendingRegistrations() {
-    while (!registrationQueue.isEmpty()) {
-      ChannelState state = registrationQueue.remove();
-      try {
-        if (!state.channel.isConnected()) {
-          state.channel.register(selector, SelectionKey.OP_CONNECT, state);
-        }
-      } catch (ClosedChannelException e) {
-        state.handleChannelException(e);
-      }
-    }
   }
 
   private static void checkTransactionTimeouts() {
@@ -71,7 +54,6 @@ final class NioTcpClient extends Client {
       return;
     }
 
-    registrationQueue.clear();
     EOFException closing = new EOFException("Client is closing");
     channelMap.forEach((key, state) -> state.handleTransactionException(closing));
     channelMap.clear();
@@ -130,7 +112,7 @@ final class NioTcpClient extends Client {
           processConnect(key);
         } else {
           if (key.isWritable()) {
-            processWrite();
+            processWrite(key);
           }
           if (key.isReadable()) {
             processRead();
@@ -163,8 +145,8 @@ final class NioTcpClient extends Client {
 
     private void processConnect(SelectionKey key) {
       try {
+        key.interestOps(SelectionKey.OP_WRITE);
         channel.finishConnect();
-        key.interestOps(SelectionKey.OP_READ | SelectionKey.OP_WRITE);
       } catch (IOException e) {
         handleChannelException(e);
       }
@@ -223,7 +205,8 @@ final class NioTcpClient extends Client {
       }
     }
 
-    private void processWrite() {
+    private void processWrite(SelectionKey key) {
+      key.interestOps(SelectionKey.OP_READ);
       for (Iterator<Transaction> it = pendingTransactions.iterator(); it.hasNext(); ) {
         Transaction t = it.next();
         try {
@@ -265,8 +248,10 @@ final class NioTcpClient extends Client {
                     c.bind(local);
                   }
 
+                  final ChannelState channelState = new ChannelState(c);
+                  c.register(selector, SelectionKey.OP_CONNECT, channelState);
                   c.connect(remote);
-                  return new ChannelState(c);
+                  return channelState;
                 } catch (IOException e) {
                   f.completeExceptionally(e);
                   return null;
@@ -279,7 +264,11 @@ final class NioTcpClient extends Client {
             Type.string(query.getQuestion().getType()));
         Transaction t = new Transaction(query, data, endTime, channel.channel, f);
         channel.pendingTransactions.add(t);
-        registrationQueue.add(channel);
+
+        // add read interest to the selection
+        final SelectionKey selectionKey = channel.channel.keyFor(selector);
+        selectionKey.interestOps(selectionKey.interestOps() | SelectionKey.OP_WRITE);
+
         selector.wakeup();
       }
     } catch (IOException e) {


### PR DESCRIPTION
Avoids putting the selector loop in full spin by removing the `OP_WRITE` selection key when there's nothing to write. I also removed the `registrationQueue` from the tcp client since we can just call connect immediately as we create the socket, and register the `OP_CONNECT` key there.

---
fixes #95