### PR TITLE
"Record" class access fixes

### DIFF
--- a/src/main/java/org/xbill/DNS/A6Record.java
+++ b/src/main/java/org/xbill/DNS/A6Record.java
@@ -40,7 +40,7 @@ public class A6Record extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     prefixBits = in.readU8();
     int suffixbits = 128 - prefixBits;
     int suffixbytes = (suffixbits + 7) / 8;
@@ -55,7 +55,7 @@ public class A6Record extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     prefixBits = st.getUInt8();
     if (prefixBits > 128) {
       throw st.exception("prefix bits must be [0..128]");
@@ -74,7 +74,7 @@ public class A6Record extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(prefixBits);
     if (suffix != null) {
@@ -104,7 +104,7 @@ public class A6Record extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(prefixBits);
     if (suffix != null) {
       int suffixbits = 128 - prefixBits;

--- a/src/main/java/org/xbill/DNS/AAAARecord.java
+++ b/src/main/java/org/xbill/DNS/AAAARecord.java
@@ -32,18 +32,18 @@ public class AAAARecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     address = in.readByteArray(16);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     address = st.getAddressBytes(Address.IPv6);
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     InetAddress addr;
     try {
       addr = InetAddress.getByAddress(null, address);
@@ -77,7 +77,7 @@ public class AAAARecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(address);
   }
 }

--- a/src/main/java/org/xbill/DNS/APLRecord.java
+++ b/src/main/java/org/xbill/DNS/APLRecord.java
@@ -128,7 +128,7 @@ public class APLRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     elements = new ArrayList<>(1);
     while (in.remaining() != 0) {
       int family = in.readU16();
@@ -155,7 +155,7 @@ public class APLRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     elements = new ArrayList<>(1);
     while (true) {
       Tokenizer.Token t = st.get();
@@ -217,7 +217,7 @@ public class APLRecord extends Record {
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     for (Iterator<Element> it = elements.iterator(); it.hasNext(); ) {
       Element element = it.next();
@@ -244,7 +244,7 @@ public class APLRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     for (Element element : elements) {
       int length;
       byte[] data;

--- a/src/main/java/org/xbill/DNS/ARecord.java
+++ b/src/main/java/org/xbill/DNS/ARecord.java
@@ -48,18 +48,18 @@ public class ARecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     addr = fromArray(in.readByteArray(4));
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     addr = fromArray(st.getAddressBytes(Address.IPv4));
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return Address.toDottedQuad(toArray(addr));
   }
 
@@ -77,7 +77,7 @@ public class ARecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU32((long) addr & 0xFFFFFFFFL);
   }
 }

--- a/src/main/java/org/xbill/DNS/CAARecord.java
+++ b/src/main/java/org/xbill/DNS/CAARecord.java
@@ -43,14 +43,14 @@ public class CAARecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     flags = in.readU8();
     tag = in.readCountedString();
     value = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     flags = st.getUInt8();
     try {
       tag = byteArrayFromString(st.getString());
@@ -61,7 +61,7 @@ public class CAARecord extends Record {
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(flags);
     sb.append(" ");
@@ -87,7 +87,7 @@ public class CAARecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(flags);
     out.writeCountedString(tag);
     out.writeByteArray(value);

--- a/src/main/java/org/xbill/DNS/CERTRecord.java
+++ b/src/main/java/org/xbill/DNS/CERTRecord.java
@@ -125,7 +125,7 @@ public class CERTRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     certType = in.readU16();
     keyTag = in.readU16();
     alg = in.readU8();
@@ -133,7 +133,7 @@ public class CERTRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String certTypeString = st.getString();
     certType = CertificateType.value(certTypeString);
     if (certType < 0) {
@@ -150,7 +150,7 @@ public class CERTRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(certType);
     sb.append(" ");
@@ -190,7 +190,7 @@ public class CERTRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(certType);
     out.writeU16(keyTag);
     out.writeU8(alg);

--- a/src/main/java/org/xbill/DNS/DHCIDRecord.java
+++ b/src/main/java/org/xbill/DNS/DHCIDRecord.java
@@ -28,22 +28,22 @@ public class DHCIDRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) {
+  protected void rrFromWire(DNSInput in) {
     data = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     data = st.getBase64();
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(data);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return base64.toString(data);
   }
 

--- a/src/main/java/org/xbill/DNS/DLVRecord.java
+++ b/src/main/java/org/xbill/DNS/DLVRecord.java
@@ -46,7 +46,7 @@ public class DLVRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     footprint = in.readU16();
     alg = in.readU8();
     digestid = in.readU8();
@@ -54,7 +54,7 @@ public class DLVRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     footprint = st.getUInt16();
     alg = st.getUInt8();
     digestid = st.getUInt8();
@@ -63,7 +63,7 @@ public class DLVRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(footprint);
     sb.append(" ");
@@ -99,7 +99,7 @@ public class DLVRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(footprint);
     out.writeU8(alg);
     out.writeU8(digestid);

--- a/src/main/java/org/xbill/DNS/DNSKEYRecord.java
+++ b/src/main/java/org/xbill/DNS/DNSKEYRecord.java
@@ -79,7 +79,7 @@ public class DNSKEYRecord extends KEYBase {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     flags = st.getUInt16();
     proto = st.getUInt8();
     String algString = st.getString();

--- a/src/main/java/org/xbill/DNS/DSRecord.java
+++ b/src/main/java/org/xbill/DNS/DSRecord.java
@@ -100,7 +100,7 @@ public class DSRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     footprint = in.readU16();
     alg = in.readU8();
     digestid = in.readU8();
@@ -108,7 +108,7 @@ public class DSRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     footprint = st.getUInt16();
     alg = st.getUInt8();
     digestid = st.getUInt8();
@@ -117,7 +117,7 @@ public class DSRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(footprint);
     sb.append(" ");
@@ -153,7 +153,7 @@ public class DSRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(footprint);
     out.writeU8(alg);
     out.writeU8(digestid);

--- a/src/main/java/org/xbill/DNS/EmptyRecord.java
+++ b/src/main/java/org/xbill/DNS/EmptyRecord.java
@@ -12,16 +12,16 @@ class EmptyRecord extends Record {
   EmptyRecord() {}
 
   @Override
-  void rrFromWire(DNSInput in) {}
+  protected void rrFromWire(DNSInput in) {}
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) {}
+  protected void rdataFromString(Tokenizer st, Name origin) {}
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return "";
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {}
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {}
 }

--- a/src/main/java/org/xbill/DNS/GPOSRecord.java
+++ b/src/main/java/org/xbill/DNS/GPOSRecord.java
@@ -63,7 +63,7 @@ public class GPOSRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     longitude = in.readCountedString();
     latitude = in.readCountedString();
     altitude = in.readCountedString();
@@ -75,7 +75,7 @@ public class GPOSRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     try {
       longitude = byteArrayFromString(st.getString());
       latitude = byteArrayFromString(st.getString());
@@ -92,7 +92,7 @@ public class GPOSRecord extends Record {
 
   /** Convert to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(byteArrayToString(longitude, true));
     sb.append(" ");
@@ -145,7 +145,7 @@ public class GPOSRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeCountedString(longitude);
     out.writeCountedString(latitude);
     out.writeCountedString(altitude);

--- a/src/main/java/org/xbill/DNS/HINFORecord.java
+++ b/src/main/java/org/xbill/DNS/HINFORecord.java
@@ -34,13 +34,13 @@ public class HINFORecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     cpu = in.readCountedString();
     os = in.readCountedString();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     try {
       cpu = byteArrayFromString(st.getString());
       os = byteArrayFromString(st.getString());
@@ -60,14 +60,14 @@ public class HINFORecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeCountedString(cpu);
     out.writeCountedString(os);
   }
 
   /** Converts to a string */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(byteArrayToString(cpu, true));
     sb.append(" ");

--- a/src/main/java/org/xbill/DNS/HIPRecord.java
+++ b/src/main/java/org/xbill/DNS/HIPRecord.java
@@ -98,7 +98,7 @@ public class HIPRecord extends Record {
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     if (Options.check("multiline")) {
       sb.append("( ");
@@ -124,7 +124,7 @@ public class HIPRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     pkAlgorithm = st.getUInt8();
     hit = st.getHexString();
     publicKey = base64.fromString(st.getString());
@@ -135,7 +135,7 @@ public class HIPRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(hit.length);
     out.writeU8(pkAlgorithm);
     out.writeU16(publicKey.length);
@@ -145,7 +145,7 @@ public class HIPRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     int hitLength = in.readU8();
     pkAlgorithm = in.readU8();
     int pkLength = in.readU16();

--- a/src/main/java/org/xbill/DNS/IPSECKEYRecord.java
+++ b/src/main/java/org/xbill/DNS/IPSECKEYRecord.java
@@ -114,7 +114,7 @@ public class IPSECKEYRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     precedence = in.readU8();
     gatewayType = in.readU8();
     algorithmType = in.readU8();
@@ -140,7 +140,7 @@ public class IPSECKEYRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     precedence = st.getUInt8();
     gatewayType = st.getUInt8();
     algorithmType = st.getUInt8();
@@ -168,7 +168,7 @@ public class IPSECKEYRecord extends Record {
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(precedence);
     sb.append(" ");
@@ -222,7 +222,7 @@ public class IPSECKEYRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(precedence);
     out.writeU8(gatewayType);
     out.writeU8(algorithmType);

--- a/src/main/java/org/xbill/DNS/ISDNRecord.java
+++ b/src/main/java/org/xbill/DNS/ISDNRecord.java
@@ -36,7 +36,7 @@ public class ISDNRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     address = in.readCountedString();
     if (in.remaining() > 0) {
       subAddress = in.readCountedString();
@@ -44,7 +44,7 @@ public class ISDNRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     try {
       address = byteArrayFromString(st.getString());
       Tokenizer.Token t = st.get();
@@ -72,7 +72,7 @@ public class ISDNRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeCountedString(address);
     if (subAddress != null) {
       out.writeCountedString(subAddress);
@@ -80,7 +80,7 @@ public class ISDNRecord extends Record {
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(byteArrayToString(address, true));
     if (subAddress != null) {

--- a/src/main/java/org/xbill/DNS/KEYBase.java
+++ b/src/main/java/org/xbill/DNS/KEYBase.java
@@ -29,7 +29,7 @@ abstract class KEYBase extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     flags = in.readU16();
     proto = in.readU8();
     alg = in.readU8();
@@ -40,7 +40,7 @@ abstract class KEYBase extends Record {
 
   /** Converts the DNSKEY/KEY Record to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(flags);
     sb.append(" ");
@@ -129,7 +129,7 @@ abstract class KEYBase extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(flags);
     out.writeU8(proto);
     out.writeU8(alg);

--- a/src/main/java/org/xbill/DNS/KEYRecord.java
+++ b/src/main/java/org/xbill/DNS/KEYRecord.java
@@ -311,7 +311,7 @@ public class KEYRecord extends KEYBase {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String flagString = st.getIdentifier();
     flags = Flags.value(flagString);
     if (flags < 0) {

--- a/src/main/java/org/xbill/DNS/LOCRecord.java
+++ b/src/main/java/org/xbill/DNS/LOCRecord.java
@@ -58,7 +58,7 @@ public class LOCRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     int version;
 
     version = in.readU8();
@@ -163,7 +163,7 @@ public class LOCRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     latitude = parsePosition(st, "latitude");
     longitude = parsePosition(st, "longitude");
     altitude = parseDouble(st, "altitude", true, -10000000, 4284967295L, 0) + 10000000;
@@ -211,7 +211,7 @@ public class LOCRecord extends Record {
 
   /** Convert to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuffer sb = new StringBuffer();
 
     /* Latitude */
@@ -272,7 +272,7 @@ public class LOCRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(0); /* version */
     out.writeU8(toLOCformat(size));
     out.writeU8(toLOCformat(hPrecision));

--- a/src/main/java/org/xbill/DNS/MINFORecord.java
+++ b/src/main/java/org/xbill/DNS/MINFORecord.java
@@ -32,20 +32,20 @@ public class MINFORecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     responsibleAddress = new Name(in);
     errorAddress = new Name(in);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     responsibleAddress = st.getName(origin);
     errorAddress = st.getName(origin);
   }
 
   /** Converts the MINFO Record to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(responsibleAddress);
     sb.append(" ");
@@ -64,7 +64,7 @@ public class MINFORecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     responsibleAddress.toWire(out, null, canonical);
     errorAddress.toWire(out, null, canonical);
   }

--- a/src/main/java/org/xbill/DNS/MXRecord.java
+++ b/src/main/java/org/xbill/DNS/MXRecord.java
@@ -35,7 +35,7 @@ public class MXRecord extends U16NameBase {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(u16Field);
     nameField.toWire(out, c, canonical);
   }

--- a/src/main/java/org/xbill/DNS/NAPTRRecord.java
+++ b/src/main/java/org/xbill/DNS/NAPTRRecord.java
@@ -55,7 +55,7 @@ public class NAPTRRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     order = in.readU16();
     preference = in.readU16();
     flags = in.readCountedString();
@@ -65,7 +65,7 @@ public class NAPTRRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     order = st.getUInt16();
     preference = st.getUInt16();
     try {
@@ -80,7 +80,7 @@ public class NAPTRRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(order);
     sb.append(" ");
@@ -127,7 +127,7 @@ public class NAPTRRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(order);
     out.writeU16(preference);
     out.writeCountedString(flags);

--- a/src/main/java/org/xbill/DNS/NSAPRecord.java
+++ b/src/main/java/org/xbill/DNS/NSAPRecord.java
@@ -63,12 +63,12 @@ public class NSAPRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) {
+  protected void rrFromWire(DNSInput in) {
     address = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String addr = st.getString();
     this.address = checkAndConvertAddress(addr);
     if (this.address == null) {
@@ -82,12 +82,12 @@ public class NSAPRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(address);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return "0x" + base16.toString(address);
   }
 }

--- a/src/main/java/org/xbill/DNS/NSEC3PARAMRecord.java
+++ b/src/main/java/org/xbill/DNS/NSEC3PARAMRecord.java
@@ -55,7 +55,7 @@ public class NSEC3PARAMRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     hashAlg = in.readU8();
     flags = in.readU8();
     iterations = in.readU16();
@@ -69,7 +69,7 @@ public class NSEC3PARAMRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(hashAlg);
     out.writeU8(flags);
     out.writeU16(iterations);
@@ -83,7 +83,7 @@ public class NSEC3PARAMRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     hashAlg = st.getUInt8();
     flags = st.getUInt8();
     iterations = st.getUInt16();
@@ -102,7 +102,7 @@ public class NSEC3PARAMRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(hashAlg);
     sb.append(' ');

--- a/src/main/java/org/xbill/DNS/NSEC3Record.java
+++ b/src/main/java/org/xbill/DNS/NSEC3Record.java
@@ -97,7 +97,7 @@ public class NSEC3Record extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     hashAlg = in.readU8();
     flags = in.readU8();
     iterations = in.readU16();
@@ -115,7 +115,7 @@ public class NSEC3Record extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(hashAlg);
     out.writeU8(flags);
     out.writeU16(iterations);
@@ -133,7 +133,7 @@ public class NSEC3Record extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     hashAlg = st.getUInt8();
     flags = st.getUInt8();
     iterations = st.getUInt16();
@@ -155,7 +155,7 @@ public class NSEC3Record extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(hashAlg);
     sb.append(' ');

--- a/src/main/java/org/xbill/DNS/NSECRecord.java
+++ b/src/main/java/org/xbill/DNS/NSECRecord.java
@@ -38,27 +38,27 @@ public class NSECRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     next = new Name(in);
     types = new TypeBitmap(in);
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     // Note: The next name is not lowercased.
     next.toWire(out, null, false);
     types.toWire(out);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     next = st.getName(origin);
     types = new TypeBitmap(st);
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(next);
     if (!types.empty()) {

--- a/src/main/java/org/xbill/DNS/NULLRecord.java
+++ b/src/main/java/org/xbill/DNS/NULLRecord.java
@@ -31,17 +31,17 @@ public class NULLRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) {
+  protected void rrFromWire(DNSInput in) {
     data = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     throw st.exception("no defined text format for NULL records");
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return unknownToString(data);
   }
 
@@ -51,7 +51,7 @@ public class NULLRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(data);
   }
 }

--- a/src/main/java/org/xbill/DNS/NXTRecord.java
+++ b/src/main/java/org/xbill/DNS/NXTRecord.java
@@ -33,7 +33,7 @@ public class NXTRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     next = new Name(in);
     bitmap = new BitSet();
     int bitmapLength = in.remaining();
@@ -48,7 +48,7 @@ public class NXTRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     next = st.getName(origin);
     bitmap = new BitSet();
     while (true) {
@@ -67,7 +67,7 @@ public class NXTRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(next);
     int length = bitmap.length();
@@ -91,7 +91,7 @@ public class NXTRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     next.toWire(out, null, canonical);
     int length = bitmap.length();
     for (int i = 0, t = 0; i < length; i++) {

--- a/src/main/java/org/xbill/DNS/OPENPGPKEYRecord.java
+++ b/src/main/java/org/xbill/DNS/OPENPGPKEYRecord.java
@@ -27,18 +27,18 @@ public class OPENPGPKEYRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) {
+  protected void rrFromWire(DNSInput in) {
     cert = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     cert = st.getBase64();
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     if (cert != null) {
       if (Options.check("multiline")) {
@@ -57,7 +57,7 @@ public class OPENPGPKEYRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(cert);
   }
 }

--- a/src/main/java/org/xbill/DNS/OPTRecord.java
+++ b/src/main/java/org/xbill/DNS/OPTRecord.java
@@ -75,7 +75,7 @@ public class OPTRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     if (in.remaining() > 0) {
       options = new ArrayList<>();
     }
@@ -86,13 +86,13 @@ public class OPTRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     throw st.exception("no text format defined for OPT");
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     if (options != null) {
       sb.append(options);
@@ -134,7 +134,7 @@ public class OPTRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     if (options == null) {
       return;
     }

--- a/src/main/java/org/xbill/DNS/PXRecord.java
+++ b/src/main/java/org/xbill/DNS/PXRecord.java
@@ -34,14 +34,14 @@ public class PXRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     preference = in.readU16();
     map822 = new Name(in);
     mapX400 = new Name(in);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     preference = st.getUInt16();
     map822 = st.getName(origin);
     mapX400 = st.getName(origin);
@@ -49,7 +49,7 @@ public class PXRecord extends Record {
 
   /** Converts the PX Record to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(preference);
     sb.append(" ");
@@ -60,7 +60,7 @@ public class PXRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(preference);
     map822.toWire(out, null, canonical);
     mapX400.toWire(out, null, canonical);

--- a/src/main/java/org/xbill/DNS/RPRecord.java
+++ b/src/main/java/org/xbill/DNS/RPRecord.java
@@ -32,20 +32,20 @@ public class RPRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     mailbox = new Name(in);
     textDomain = new Name(in);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     mailbox = st.getName(origin);
     textDomain = st.getName(origin);
   }
 
   /** Converts the RP Record to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(mailbox);
     sb.append(" ");
@@ -64,7 +64,7 @@ public class RPRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     mailbox.toWire(out, null, canonical);
     textDomain.toWire(out, null, canonical);
   }

--- a/src/main/java/org/xbill/DNS/Record.java
+++ b/src/main/java/org/xbill/DNS/Record.java
@@ -28,7 +28,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
 
   protected Record() {}
 
-  Record(Name name, int type, int dclass, long ttl) {
+  protected Record(Name name, int type, int dclass, long ttl) {
     if (!name.isAbsolute()) {
       throw new RelativeNameException(name);
     }
@@ -61,7 +61,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to wire format - must be overridden */
-  abstract void rrFromWire(DNSInput in) throws IOException;
+  abstract protected void rrFromWire(DNSInput in) throws IOException;
 
   private static Record newRecord(
       Name name, int type, int dclass, long ttl, int length, DNSInput in) throws IOException {
@@ -262,7 +262,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to text format - must be overriden */
-  abstract String rrToString();
+  abstract protected String rrToString();
 
   /** Converts the rdata portion of a Record into a String representation */
   public String rdataToString() {
@@ -301,7 +301,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the text format of an RR to the internal format - must be overriden */
-  abstract void rdataFromString(Tokenizer st, Name origin) throws IOException;
+  abstract protected void rdataFromString(Tokenizer st, Name origin) throws IOException;
 
   /** Converts a String into a byte array. */
   protected static byte[] byteArrayFromString(String s) throws TextParseException {
@@ -504,7 +504,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to wire format - must be overriden */
-  abstract void rrToWire(DNSOutput out, Compression c, boolean canonical);
+  abstract protected void rrToWire(DNSOutput out, Compression c, boolean canonical);
 
   /**
    * Determines if two Records could be part of the same RRset. This compares the name, type, and

--- a/src/main/java/org/xbill/DNS/Record.java
+++ b/src/main/java/org/xbill/DNS/Record.java
@@ -61,7 +61,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to wire format - must be overridden */
-  abstract protected void rrFromWire(DNSInput in) throws IOException;
+  protected abstract void rrFromWire(DNSInput in) throws IOException;
 
   private static Record newRecord(
       Name name, int type, int dclass, long ttl, int length, DNSInput in) throws IOException {
@@ -262,7 +262,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to text format - must be overriden */
-  abstract protected String rrToString();
+  protected abstract String rrToString();
 
   /** Converts the rdata portion of a Record into a String representation */
   public String rdataToString() {
@@ -301,7 +301,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the text format of an RR to the internal format - must be overriden */
-  abstract protected void rdataFromString(Tokenizer st, Name origin) throws IOException;
+  protected abstract void rdataFromString(Tokenizer st, Name origin) throws IOException;
 
   /** Converts a String into a byte array. */
   protected static byte[] byteArrayFromString(String s) throws TextParseException {
@@ -504,7 +504,7 @@ public abstract class Record implements Cloneable, Comparable<Record> {
   }
 
   /** Converts the type-specific RR to wire format - must be overriden */
-  abstract protected void rrToWire(DNSOutput out, Compression c, boolean canonical);
+  protected abstract void rrToWire(DNSOutput out, Compression c, boolean canonical);
 
   /**
    * Determines if two Records could be part of the same RRset. This compares the name, type, and

--- a/src/main/java/org/xbill/DNS/SIGBase.java
+++ b/src/main/java/org/xbill/DNS/SIGBase.java
@@ -54,7 +54,7 @@ abstract class SIGBase extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     covered = in.readU16();
     alg = in.readU8();
     labels = in.readU8();
@@ -67,7 +67,7 @@ abstract class SIGBase extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String typeString = st.getString();
     covered = Type.value(typeString);
     if (covered < 0) {
@@ -89,7 +89,7 @@ abstract class SIGBase extends Record {
 
   /** Converts the RRSIG/SIG Record to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(Type.string(covered));
     sb.append(" ");
@@ -186,7 +186,7 @@ abstract class SIGBase extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(covered);
     out.writeU8(alg);
     out.writeU8(labels);

--- a/src/main/java/org/xbill/DNS/SOARecord.java
+++ b/src/main/java/org/xbill/DNS/SOARecord.java
@@ -50,7 +50,7 @@ public class SOARecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     host = new Name(in);
     admin = new Name(in);
     serial = in.readU32();
@@ -61,7 +61,7 @@ public class SOARecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     host = st.getName(origin);
     admin = st.getName(origin);
     serial = st.getUInt32();
@@ -73,7 +73,7 @@ public class SOARecord extends Record {
 
   /** Convert to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(host);
     sb.append(" ");
@@ -141,7 +141,7 @@ public class SOARecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     host.toWire(out, c, canonical);
     admin.toWire(out, c, canonical);
     out.writeU32(serial);

--- a/src/main/java/org/xbill/DNS/SRVRecord.java
+++ b/src/main/java/org/xbill/DNS/SRVRecord.java
@@ -37,7 +37,7 @@ public class SRVRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     priority = in.readU16();
     weight = in.readU16();
     port = in.readU16();
@@ -45,7 +45,7 @@ public class SRVRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     priority = st.getUInt16();
     weight = st.getUInt16();
     port = st.getUInt16();
@@ -54,7 +54,7 @@ public class SRVRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(priority).append(" ");
     sb.append(weight).append(" ");
@@ -84,7 +84,7 @@ public class SRVRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(priority);
     out.writeU16(weight);
     out.writeU16(port);

--- a/src/main/java/org/xbill/DNS/SSHFPRecord.java
+++ b/src/main/java/org/xbill/DNS/SSHFPRecord.java
@@ -47,21 +47,21 @@ public class SSHFPRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     alg = in.readU8();
     digestType = in.readU8();
     fingerprint = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     alg = st.getUInt8();
     digestType = st.getUInt8();
     fingerprint = st.getHex(true);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(alg);
     sb.append(" ");
@@ -87,7 +87,7 @@ public class SSHFPRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(alg);
     out.writeU8(digestType);
     out.writeByteArray(fingerprint);

--- a/src/main/java/org/xbill/DNS/SingleCompressedNameBase.java
+++ b/src/main/java/org/xbill/DNS/SingleCompressedNameBase.java
@@ -17,7 +17,7 @@ abstract class SingleCompressedNameBase extends SingleNameBase {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     singleName.toWire(out, c, canonical);
   }
 }

--- a/src/main/java/org/xbill/DNS/SingleNameBase.java
+++ b/src/main/java/org/xbill/DNS/SingleNameBase.java
@@ -25,17 +25,17 @@ abstract class SingleNameBase extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     singleName = new Name(in);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     singleName = st.getName(origin);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return singleName.toString();
   }
 
@@ -44,7 +44,7 @@ abstract class SingleNameBase extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     singleName.toWire(out, null, canonical);
   }
 }

--- a/src/main/java/org/xbill/DNS/TKEYRecord.java
+++ b/src/main/java/org/xbill/DNS/TKEYRecord.java
@@ -113,7 +113,7 @@ public class TKEYRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     alg = new Name(in);
     timeInception = Instant.ofEpochSecond(in.readU32());
     timeExpire = Instant.ofEpochSecond(in.readU32());
@@ -136,7 +136,7 @@ public class TKEYRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     throw st.exception("no text format defined for TKEY");
   }
 
@@ -159,7 +159,7 @@ public class TKEYRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(alg);
     sb.append(" ");
@@ -232,7 +232,7 @@ public class TKEYRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     alg.toWire(out, null, canonical);
 
     out.writeU32(timeInception.getEpochSecond());

--- a/src/main/java/org/xbill/DNS/TLSARecord.java
+++ b/src/main/java/org/xbill/DNS/TLSARecord.java
@@ -109,7 +109,7 @@ public class TLSARecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     certificateUsage = in.readU8();
     selector = in.readU8();
     matchingType = in.readU8();
@@ -117,7 +117,7 @@ public class TLSARecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     certificateUsage = st.getUInt8();
     selector = st.getUInt8();
     matchingType = st.getUInt8();
@@ -126,7 +126,7 @@ public class TLSARecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(certificateUsage);
     sb.append(" ");
@@ -140,7 +140,7 @@ public class TLSARecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU8(certificateUsage);
     out.writeU8(selector);
     out.writeU8(matchingType);

--- a/src/main/java/org/xbill/DNS/TSIGRecord.java
+++ b/src/main/java/org/xbill/DNS/TSIGRecord.java
@@ -105,7 +105,7 @@ public class TSIGRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     alg = new Name(in);
 
     long timeHigh = in.readU16();
@@ -129,13 +129,13 @@ public class TSIGRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     throw st.exception("no text format defined for TSIG");
   }
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(alg);
     sb.append(" ");
@@ -230,7 +230,7 @@ public class TSIGRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     alg.toWire(out, null, canonical);
 
     long time = timeSigned.getEpochSecond();

--- a/src/main/java/org/xbill/DNS/TXTBase.java
+++ b/src/main/java/org/xbill/DNS/TXTBase.java
@@ -44,7 +44,7 @@ abstract class TXTBase extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     strings = new ArrayList<>(2);
     while (in.remaining() > 0) {
       byte[] b = in.readCountedString();
@@ -53,7 +53,7 @@ abstract class TXTBase extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     strings = new ArrayList<>(2);
     while (true) {
       Tokenizer.Token t = st.get();
@@ -71,7 +71,7 @@ abstract class TXTBase extends Record {
 
   /** converts to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     Iterator<byte[]> it = strings.iterator();
     while (it.hasNext()) {
@@ -107,7 +107,7 @@ abstract class TXTBase extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     for (byte[] b : strings) {
       out.writeCountedString(b);
     }

--- a/src/main/java/org/xbill/DNS/U16NameBase.java
+++ b/src/main/java/org/xbill/DNS/U16NameBase.java
@@ -35,19 +35,19 @@ abstract class U16NameBase extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     u16Field = in.readU16();
     nameField = new Name(in);
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     u16Field = st.getUInt16();
     nameField = st.getName(origin);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(u16Field);
     sb.append(" ");
@@ -64,7 +64,7 @@ abstract class U16NameBase extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(u16Field);
     nameField.toWire(out, null, canonical);
   }

--- a/src/main/java/org/xbill/DNS/UNKRecord.java
+++ b/src/main/java/org/xbill/DNS/UNKRecord.java
@@ -16,18 +16,18 @@ public class UNKRecord extends Record {
   UNKRecord() {}
 
   @Override
-  void rrFromWire(DNSInput in) {
+  protected void rrFromWire(DNSInput in) {
     data = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     throw st.exception("invalid unknown RR encoding");
   }
 
   /** Converts this Record to the String "unknown format" */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return unknownToString(data);
   }
 
@@ -37,7 +37,7 @@ public class UNKRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(data);
   }
 }

--- a/src/main/java/org/xbill/DNS/URIRecord.java
+++ b/src/main/java/org/xbill/DNS/URIRecord.java
@@ -39,14 +39,14 @@ public class URIRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     priority = in.readU16();
     weight = in.readU16();
     target = in.readByteArray();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     priority = st.getUInt16();
     weight = st.getUInt16();
     try {
@@ -58,7 +58,7 @@ public class URIRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(priority).append(" ");
     sb.append(weight).append(" ");
@@ -82,7 +82,7 @@ public class URIRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeU16(priority);
     out.writeU16(weight);
     out.writeByteArray(target);

--- a/src/main/java/org/xbill/DNS/WKSRecord.java
+++ b/src/main/java/org/xbill/DNS/WKSRecord.java
@@ -597,7 +597,7 @@ public class WKSRecord extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     address = in.readByteArray(4);
     protocol = in.readU8();
     byte[] array = in.readByteArray();
@@ -617,7 +617,7 @@ public class WKSRecord extends Record {
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String s = st.getString();
     address = Address.toByteArray(s, Address.IPv4);
     if (address == null) {
@@ -651,7 +651,7 @@ public class WKSRecord extends Record {
 
   /** Converts rdata to a String */
   @Override
-  String rrToString() {
+  protected String rrToString() {
     StringBuilder sb = new StringBuilder();
     sb.append(Address.toDottedQuad(address));
     sb.append(" ");
@@ -682,7 +682,7 @@ public class WKSRecord extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeByteArray(address);
     out.writeU8(protocol);
     int highestPort = services[services.length - 1];

--- a/src/main/java/org/xbill/DNS/X25Record.java
+++ b/src/main/java/org/xbill/DNS/X25Record.java
@@ -44,12 +44,12 @@ public class X25Record extends Record {
   }
 
   @Override
-  void rrFromWire(DNSInput in) throws IOException {
+  protected void rrFromWire(DNSInput in) throws IOException {
     address = in.readCountedString();
   }
 
   @Override
-  void rdataFromString(Tokenizer st, Name origin) throws IOException {
+  protected void rdataFromString(Tokenizer st, Name origin) throws IOException {
     String addr = st.getString();
     this.address = checkAndConvertAddress(addr);
     if (this.address == null) {
@@ -63,12 +63,12 @@ public class X25Record extends Record {
   }
 
   @Override
-  void rrToWire(DNSOutput out, Compression c, boolean canonical) {
+  protected void rrToWire(DNSOutput out, Compression c, boolean canonical) {
     out.writeCountedString(address);
   }
 
   @Override
-  String rrToString() {
+  protected String rrToString() {
     return byteArrayToString(address, true);
   }
 }

--- a/src/test/java/org/xbill/DNS/KEYBaseTest.java
+++ b/src/test/java/org/xbill/DNS/KEYBaseTest.java
@@ -53,7 +53,7 @@ class KEYBaseTest {
     }
 
     @Override
-    void rdataFromString(Tokenizer st, Name origin) {}
+    protected void rdataFromString(Tokenizer st, Name origin) {}
   }
 
   @Test


### PR DESCRIPTION
"package" access in the Record class disallows subclasses to reside in other packages. The submitted fix relaxes the access to four methods and a constructor to "protected" access. All required existing subclasses needed to be adjusted as well.