### PR TITLE
Refactor TSIG handling

### DIFF
--- a/src/main/java/org/xbill/DNS/DNSOutput.java
+++ b/src/main/java/org/xbill/DNS/DNSOutput.java
@@ -181,4 +181,8 @@ public class DNSOutput {
     System.arraycopy(array, 0, out, 0, pos);
     return out;
   }
+
+  static byte[] toU16(int val) {
+    return new byte[] {(byte) ((val >>> 8) & 0xFF), (byte) (val & 0xFF)};
+  }
 }

--- a/src/main/java/org/xbill/DNS/TSIG.java
+++ b/src/main/java/org/xbill/DNS/TSIG.java
@@ -3,17 +3,20 @@
 package org.xbill.DNS;
 
 import java.security.GeneralSecurityException;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
 import org.xbill.DNS.utils.base64;
+import org.xbill.DNS.utils.hexdump;
 
 /**
  * Transaction signature handling. This class generates and verifies TSIG records on messages, which
@@ -50,7 +53,7 @@ public class TSIG {
   /** The domain name representing the HMAC-SHA512 algorithm. */
   public static final Name HMAC_SHA512 = Name.fromConstantString("hmac-sha512.");
 
-  private static Map<Name, String> algMap;
+  private static final Map<Name, String> algMap;
 
   static {
     Map<Name, String> out = new HashMap<>();
@@ -69,7 +72,7 @@ public class TSIG {
         return entry.getKey();
       }
     }
-    throw new IllegalArgumentException("Unknown algorithm");
+    throw new IllegalArgumentException("Unknown algorithm: " + alg);
   }
 
   public static String nameToAlgorithm(Name name) {
@@ -77,38 +80,26 @@ public class TSIG {
     if (alg != null) {
       return alg;
     }
-    throw new IllegalArgumentException("Unknown algorithm");
+    throw new IllegalArgumentException("Unknown algorithm: " + name);
   }
 
   /** The default fudge value for outgoing packets. Can be overridden by the tsigfudge option. */
   public static final Duration FUDGE = Duration.ofSeconds(300);
 
-  private Name name, alg;
-  private Mac hmac;
+  private final Name alg;
+  private final Clock clock;
+  private final Name name;
+  private final Mac hmac;
 
   /**
    * Verifies the data (computes the secure hash and compares it to the input)
    *
-   * @param mac The HMAC generator
+   * @param expected The expected (locally calculated) signature
    * @param signature The signature to compare against
    * @return true if the signature matches, false otherwise
    */
-  private static boolean verify(Mac mac, byte[] signature) {
-    return verify(mac, signature, false);
-  }
-
-  /**
-   * Verifies the data (computes the secure hash and compares it to the input)
-   *
-   * @param mac The HMAC generator
-   * @param signature The signature to compare against
-   * @param truncation_ok If true, the signature may be truncated; only the number of bytes in the
-   *     provided signature are compared.
-   * @return true if the signature matches, false otherwise
-   */
-  private static boolean verify(Mac mac, byte[] signature, boolean truncation_ok) {
-    byte[] expected = mac.doFinal();
-    if (truncation_ok && signature.length < expected.length) {
+  private static boolean verify(byte[] expected, byte[] signature) {
+    if (signature.length < expected.length) {
       byte[] truncated = new byte[signature.length];
       System.arraycopy(expected, 0, truncated, 0, truncated.length);
       expected = truncated;
@@ -116,13 +107,28 @@ public class TSIG {
     return Arrays.equals(signature, expected);
   }
 
-  private void init_hmac(String macAlgorithm, SecretKey key) {
+  private Mac initHmac(String macAlgorithm, SecretKey key) {
     try {
-      hmac = Mac.getInstance(macAlgorithm);
-      hmac.init(key);
+      Mac mac = Mac.getInstance(macAlgorithm);
+      mac.init(key);
+      return mac;
     } catch (GeneralSecurityException ex) {
-      throw new IllegalArgumentException("Caught security exception setting up HMAC.");
+      throw new IllegalArgumentException("Caught security exception setting up HMAC.", ex);
     }
+  }
+
+  /**
+   * Creates a new TSIG object, which can be used to sign or verify a message.
+   *
+   * @param name The name of the shared key.
+   * @param key The shared key's data represented as a base64 encoded string.
+   * @throws IllegalArgumentException The key name is an invalid name
+   * @throws IllegalArgumentException The key data is improperly encoded
+   * @throws NullPointerException key is null
+   * @since 3.2
+   */
+  public TSIG(Name algorithm, Name name, String key) {
+    this(algorithm, name, Objects.requireNonNull(base64.fromString(key)));
   }
 
   /**
@@ -135,9 +141,10 @@ public class TSIG {
   public TSIG(Name algorithm, Name name, byte[] keyBytes) {
     this.name = name;
     this.alg = algorithm;
+    this.clock = Clock.systemUTC();
     String macAlgorithm = nameToAlgorithm(algorithm);
     SecretKey key = new SecretKeySpec(keyBytes, macAlgorithm);
-    init_hmac(macAlgorithm, key);
+    this.hmac = initHmac(macAlgorithm, key);
   }
 
   /**
@@ -148,10 +155,23 @@ public class TSIG {
    * @param key The shared key.
    */
   public TSIG(Name algorithm, Name name, SecretKey key) {
+    this(algorithm, name, key, Clock.systemUTC());
+  }
+
+  /**
+   * Creates a new TSIG key, which can be used to sign or verify a message.
+   *
+   * @param algorithm The algorithm of the shared key.
+   * @param name The name of the shared key.
+   * @param key The shared key.
+   * @since 3.2
+   */
+  public TSIG(Name algorithm, Name name, SecretKey key, Clock clock) {
     this.name = name;
     this.alg = algorithm;
+    this.clock = clock;
     String macAlgorithm = nameToAlgorithm(algorithm);
-    init_hmac(macAlgorithm, key);
+    this.hmac = initHmac(macAlgorithm, key);
   }
 
   /**
@@ -164,15 +184,17 @@ public class TSIG {
   public TSIG(Mac mac, Name name) {
     this.name = name;
     this.hmac = mac;
+    this.clock = Clock.systemUTC();
     this.alg = algorithmToName(mac.getAlgorithm());
   }
 
   /**
-   * Creates a new TSIG key with the hmac-md5 algorithm, which can be used to sign or verify a
-   * message.
+   * Creates a new TSIG key with the {@link #HMAC_MD5} algorithm, which can be used to sign or
+   * verify a message.
    *
    * @param name The name of the shared key.
    * @param key The shared key's data.
+   * @deprecated Use {@link #TSIG(Name, Name, SecretKey)} to explicitly specify an algorithm.
    */
   public TSIG(Name name, byte[] key) {
     this(HMAC_MD5, name, key);
@@ -197,8 +219,9 @@ public class TSIG {
       throw new IllegalArgumentException("Invalid TSIG key name");
     }
     this.alg = algorithm;
+    this.clock = Clock.systemUTC();
     String macAlgorithm = nameToAlgorithm(this.alg);
-    init_hmac(macAlgorithm, new SecretKeySpec(keyBytes, macAlgorithm));
+    this.hmac = initHmac(macAlgorithm, new SecretKeySpec(keyBytes, macAlgorithm));
   }
 
   /**
@@ -216,13 +239,14 @@ public class TSIG {
   }
 
   /**
-   * Creates a new TSIG object with the hmac-md5 algorithm, which can be used to sign or verify a
-   * message.
+   * Creates a new TSIG object with the {@link #HMAC_MD5} algorithm, which can be used to sign or
+   * verify a message.
    *
    * @param name The name of the shared key
    * @param key The shared key's data, represented as a base64 encoded string.
    * @throws IllegalArgumentException The key name is an invalid name
    * @throws IllegalArgumentException The key data is improperly encoded
+   * @deprecated Use {@link #TSIG(Name, String, String)} to explicitly specify an algorithm.
    */
   public TSIG(String name, String key) {
     this(HMAC_MD5, name, key);
@@ -232,25 +256,22 @@ public class TSIG {
    * Creates a new TSIG object, which can be used to sign or verify a message.
    *
    * @param str The TSIG key, in the form name:secret, name/secret, alg:name:secret, or
-   *     alg/name/secret. If an algorithm is specified, it must be "hmac-md5", "hmac-sha1", or
-   *     "hmac-sha256".
+   *     alg/name/secret. If no algorithm is specified, the default of {@link #HMAC_MD5} is used.
    * @throws IllegalArgumentException The string does not contain both a name and secret.
    * @throws IllegalArgumentException The key name is an invalid name
    * @throws IllegalArgumentException The key data is improperly encoded
+   * @deprecated Use an explicit constructor
    */
   public static TSIG fromString(String str) {
     String[] parts = str.split("[:/]", 3);
-    if (parts.length < 2) {
-      throw new IllegalArgumentException("Invalid TSIG key specification");
-    }
-    if (parts.length == 3) {
-      try {
+    switch (parts.length) {
+      case 2:
+        return new TSIG(HMAC_MD5, parts[0], parts[1]);
+      case 3:
         return new TSIG(parts[0], parts[1], parts[2]);
-      } catch (IllegalArgumentException e) {
-        parts = str.split("[:/]", 2);
-      }
+      default:
+        throw new IllegalArgumentException("Invalid TSIG key specification");
     }
-    return new TSIG(HMAC_MD5, parts[0], parts[1]);
   }
 
   /**
@@ -263,19 +284,39 @@ public class TSIG {
    * @return The TSIG record to be added to the message
    */
   public TSIGRecord generate(Message m, byte[] b, int error, TSIGRecord old) {
+    return generate(m, b, error, old, true);
+  }
+
+  /**
+   * Generates a TSIG record with a specific error for a message that has been rendered.
+   *
+   * @param m The message
+   * @param b The rendered message
+   * @param error The error
+   * @param old If this message is a response, the TSIG from the request
+   * @param fullSignature {@code true} if this {@link TSIGRecord} is the to be added to the first of
+   *     many messages in a TCP connection and all TSIG variables (rfc2845, 3.4.2.) should be
+   *     included in the signature. {@code false} for subsequent messages with reduced TSIG
+   *     variables set (rfc2845, 4.4.).
+   * @return The TSIG record to be added to the message
+   * @since 3.2
+   */
+  public TSIGRecord generate(
+      Message m, byte[] b, int error, TSIGRecord old, boolean fullSignature) {
     Instant timeSigned;
-    if (error != Rcode.BADTIME) {
-      timeSigned = Instant.now();
-    } else {
+    if (error == Rcode.BADTIME) {
       timeSigned = old.getTimeSigned();
+    } else {
+      timeSigned = clock.instant();
     }
-    Duration fudge;
+
     boolean signing = false;
-    if (error == Rcode.NOERROR || error == Rcode.BADTIME) {
+    if (error == Rcode.NOERROR || error == Rcode.BADTIME || error == Rcode.BADTRUNC) {
       signing = true;
       hmac.reset();
     }
 
+    Duration fudge;
     int fudgeOption = Options.intValue("tsigfudge");
     if (fudgeOption < 0 || fudgeOption > 0x7FFF) {
       fudge = FUDGE;
@@ -283,54 +324,49 @@ public class TSIG {
       fudge = Duration.ofSeconds(fudgeOption);
     }
 
-    if (old != null) {
-      DNSOutput out = new DNSOutput();
-      out.writeU16(old.getSignature().length);
-      if (signing) {
-        hmac.update(out.toByteArray());
-        hmac.update(old.getSignature());
-      }
+    if (old != null && signing) {
+      hmacAddSignature(hmac, old);
     }
 
-    /* Digest the message */
+    // Digest the message
     if (signing) {
+      if (log.isTraceEnabled()) {
+        log.trace(hexdump.dump("TSIG-HMAC rendered message", b));
+      }
       hmac.update(b);
     }
 
+    // rfc2845, 3.4.2 TSIG Variables
+    // for section 4.4 TSIG on TCP connection: skip name, class, ttl, alg and other
     DNSOutput out = new DNSOutput();
-    name.toWireCanonical(out);
-    out.writeU16(DClass.ANY); /* class */
-    out.writeU32(0); /* ttl */
-    alg.toWireCanonical(out);
-    long time = timeSigned.getEpochSecond();
-    int timeHigh = (int) (time >> 32);
-    long timeLow = time & 0xFFFFFFFFL;
-    out.writeU16(timeHigh);
-    out.writeU32(timeLow);
-    out.writeU16((int) fudge.getSeconds());
+    if (fullSignature) {
+      name.toWireCanonical(out);
+      out.writeU16(DClass.ANY); /* class */
+      out.writeU32(0); /* ttl */
+      alg.toWireCanonical(out);
+    }
 
-    out.writeU16(error);
-    out.writeU16(0); /* No other data */
-
-    if (signing) {
-      hmac.update(out.toByteArray());
+    writeTsigTimersVariables(timeSigned, fudge, out);
+    if (fullSignature) {
+      out.writeU16(error);
+      out.writeU16(0); /* No other data */
     }
 
     byte[] signature;
     if (signing) {
-      signature = hmac.doFinal();
+      byte[] tsigVariables = out.toByteArray();
+      if (log.isTraceEnabled()) {
+        log.trace(hexdump.dump("TSIG-HMAC variables", tsigVariables));
+      }
+      signature = hmac.doFinal(tsigVariables);
     } else {
       signature = new byte[0];
     }
 
     byte[] other = null;
     if (error == Rcode.BADTIME) {
-      out = new DNSOutput();
-      time = Instant.now().getEpochSecond();
-      timeHigh = (int) (time >> 32);
-      timeLow = time & 0xFFFFFFFFL;
-      out.writeU16(timeHigh);
-      out.writeU32(timeLow);
+      out = new DNSOutput(6);
+      writeTsigTime(clock.instant(), out);
       other = out.toByteArray();
     }
 
@@ -348,6 +384,16 @@ public class TSIG {
   }
 
   /**
+   * Generates a TSIG record for a message and adds it to the message
+   *
+   * @param m The message
+   * @param old If this message is a response, the TSIG from the request
+   */
+  public void apply(Message m, TSIGRecord old) {
+    apply(m, Rcode.NOERROR, old, true);
+  }
+
+  /**
    * Generates a TSIG record with a specific error for a message and adds it to the message.
    *
    * @param m The message
@@ -355,7 +401,36 @@ public class TSIG {
    * @param old If this message is a response, the TSIG from the request
    */
   public void apply(Message m, int error, TSIGRecord old) {
-    Record r = generate(m, m.toWire(), error, old);
+    apply(m, error, old, true);
+  }
+
+  /**
+   * Generates a TSIG record with a specific error for a message and adds it to the message.
+   *
+   * @param m The message
+   * @param old If this message is a response, the TSIG from the request
+   * @param fullSignature {@code true} if this message is the first of many in a TCP connection and
+   *     all TSIG variables (rfc2845, 3.4.2.) should be included in the signature. {@code false} for
+   *     subsequent messages with reduced TSIG variables set (rfc2845, 4.4.).
+   * @since 3.2
+   */
+  public void apply(Message m, TSIGRecord old, boolean fullSignature) {
+    apply(m, Rcode.NOERROR, old, fullSignature);
+  }
+
+  /**
+   * Generates a TSIG record with a specific error for a message and adds it to the message.
+   *
+   * @param m The message
+   * @param error The error
+   * @param old If this message is a response, the TSIG from the request
+   * @param fullSignature {@code true} if this message is the first of many in a TCP connection and
+   *     all TSIG variables (rfc2845, 3.4.2.) should be included in the signature. {@code false} for
+   *     subsequent messages with reduced TSIG variables set (rfc2845, 4.4.).
+   * @since 3.2
+   */
+  public void apply(Message m, int error, TSIGRecord old, boolean fullSignature) {
+    Record r = generate(m, m.toWire(), error, old, fullSignature);
     m.addRecord(r, Section.ADDITIONAL);
     m.tsigState = Message.TSIG_SIGNED;
   }
@@ -365,66 +440,13 @@ public class TSIG {
    *
    * @param m The message
    * @param old If this message is a response, the TSIG from the request
+   * @param fullSignature {@code true} if this message is the first of many in a TCP connection and
+   *     all TSIG variables (rfc2845, 3.4.2.) should be included in the signature. {@code false} for
+   *     subsequent messages with reduced TSIG variables set (rfc2845, 4.4.).
+   * @deprecated use {@link #apply(Message, TSIGRecord, boolean)}
    */
-  public void apply(Message m, TSIGRecord old) {
-    apply(m, Rcode.NOERROR, old);
-  }
-
-  /**
-   * Generates a TSIG record for a message and adds it to the message
-   *
-   * @param m The message
-   * @param old If this message is a response, the TSIG from the request
-   */
-  public void applyStream(Message m, TSIGRecord old, boolean first) {
-    if (first) {
-      apply(m, old);
-      return;
-    }
-    Instant timeSigned = Instant.now();
-    Duration fudge;
-    hmac.reset();
-
-    int fudgeOption = Options.intValue("tsigfudge");
-    if (fudgeOption < 0 || fudgeOption > 0x7FFF) {
-      fudge = FUDGE;
-    } else {
-      fudge = Duration.ofSeconds(fudgeOption);
-    }
-
-    DNSOutput out = new DNSOutput();
-    out.writeU16(old.getSignature().length);
-    hmac.update(out.toByteArray());
-    hmac.update(old.getSignature());
-
-    /* Digest the message */
-    hmac.update(m.toWire());
-
-    out = new DNSOutput();
-    long time = timeSigned.getEpochSecond();
-    int timeHigh = (int) (time >> 32);
-    long timeLow = time & 0xFFFFFFFFL;
-    out.writeU16(timeHigh);
-    out.writeU32(timeLow);
-    out.writeU16((int) fudge.getSeconds());
-
-    hmac.update(out.toByteArray());
-
-    byte[] signature = hmac.doFinal();
-    Record r =
-        new TSIGRecord(
-            name,
-            DClass.ANY,
-            0,
-            alg,
-            timeSigned,
-            fudge,
-            signature,
-            m.getHeader().getID(),
-            Rcode.NOERROR,
-            null);
-    m.addRecord(r, Section.ADDITIONAL);
-    m.tsigState = Message.TSIG_SIGNED;
+  public void applyStream(Message m, TSIGRecord old, boolean fullSignature) {
+    apply(m, Rcode.NOERROR, old, fullSignature);
   }
 
   /**
@@ -461,76 +483,128 @@ public class TSIG {
    * @see Rcode
    */
   public int verify(Message m, byte[] b, TSIGRecord old) {
+    return verify(m, b, old, true);
+  }
+
+  /**
+   * Verifies a TSIG record on an incoming message. Since this is only called in the context where a
+   * TSIG is expected to be present, it is an error if one is not present. After calling this
+   * routine, Message.isVerified() may be called on this message.
+   *
+   * @param m The message to verify
+   * @param b An array containing the message in unparsed form. This is necessary since TSIG signs
+   *     the message in wire format, and we can't recreate the exact wire format (with the same name
+   *     compression).
+   * @param old If this message is a response, the TSIG from the request
+   * @param fullSignature {@code true} if this message is the first of many in a TCP connection and
+   *     all TSIG variables (rfc2845, 3.4.2.) should be included in the signature. {@code false} for
+   *     subsequent messages with reduced TSIG variables set (rfc2845, 4.4.).
+   * @return The result of the verification (as an Rcode)
+   * @see Rcode
+   * @since 3.2
+   */
+  public int verify(Message m, byte[] b, TSIGRecord old, boolean fullSignature) {
     m.tsigState = Message.TSIG_FAILED;
     TSIGRecord tsig = m.getTSIG();
-    hmac.reset();
     if (tsig == null) {
       return Rcode.FORMERR;
     }
 
     if (!tsig.getName().equals(name) || !tsig.getAlgorithm().equals(alg)) {
-      log.debug("BADKEY failure");
+      log.debug(
+          "BADKEY failure, expected: {}/{}, actual: {}/{}",
+          name,
+          alg,
+          tsig.getName(),
+          tsig.getAlgorithm());
       return Rcode.BADKEY;
     }
-    Duration delta = Duration.between(Instant.now(), tsig.getTimeSigned()).abs();
-    if (delta.compareTo(tsig.getFudge()) > 0) {
-      log.debug("BADTIME failure");
-      return Rcode.BADTIME;
+
+    hmac.reset();
+    if (old != null && tsig.getError() != Rcode.BADKEY && tsig.getError() != Rcode.BADSIG) {
+      hmacAddSignature(hmac, old);
     }
 
-    if (old != null && tsig.getError() != Rcode.BADKEY && tsig.getError() != Rcode.BADSIG) {
-      DNSOutput out = new DNSOutput();
-      out.writeU16(old.getSignature().length);
-      hmac.update(out.toByteArray());
-      hmac.update(old.getSignature());
-    }
     m.getHeader().decCount(Section.ADDITIONAL);
     byte[] header = m.getHeader().toWire();
     m.getHeader().incCount(Section.ADDITIONAL);
+    if (log.isTraceEnabled()) {
+      log.trace(hexdump.dump("TSIG-HMAC header", header));
+    }
     hmac.update(header);
 
     int len = m.tsigstart - header.length;
+    if (log.isTraceEnabled()) {
+      log.trace(hexdump.dump("TSIG-HMAC message after header", b, header.length, len));
+    }
     hmac.update(b, header.length, len);
 
     DNSOutput out = new DNSOutput();
-    tsig.getName().toWireCanonical(out);
-    out.writeU16(tsig.dclass);
-    out.writeU32(tsig.ttl);
-    tsig.getAlgorithm().toWireCanonical(out);
-    long time = tsig.getTimeSigned().getEpochSecond();
-    int timeHigh = (int) (time >> 32);
-    long timeLow = time & 0xFFFFFFFFL;
-    out.writeU16(timeHigh);
-    out.writeU32(timeLow);
-    out.writeU16((int) tsig.getFudge().getSeconds());
-    out.writeU16(tsig.getError());
-    if (tsig.getOther() != null) {
-      out.writeU16(tsig.getOther().length);
-      out.writeByteArray(tsig.getOther());
-    } else {
-      out.writeU16(0);
+    if (fullSignature) {
+      tsig.getName().toWireCanonical(out);
+      out.writeU16(tsig.dclass);
+      out.writeU32(tsig.ttl);
+      tsig.getAlgorithm().toWireCanonical(out);
+    }
+    writeTsigTimersVariables(tsig.getTimeSigned(), tsig.getFudge(), out);
+    if (fullSignature) {
+      out.writeU16(tsig.getError());
+      if (tsig.getOther() != null) {
+        out.writeU16(tsig.getOther().length);
+        out.writeByteArray(tsig.getOther());
+      } else {
+        out.writeU16(0);
+      }
     }
 
-    hmac.update(out.toByteArray());
+    byte[] tsigVariables = out.toByteArray();
+    if (log.isTraceEnabled()) {
+      log.trace(hexdump.dump("TSIG-HMAC variables", tsigVariables));
+    }
+    hmac.update(tsigVariables);
 
     byte[] signature = tsig.getSignature();
     int digestLength = hmac.getMacLength();
-    int minDigestLength;
-    if (hmac.getAlgorithm().toLowerCase().contains("md5")) {
-      minDigestLength = 10;
-    } else {
-      minDigestLength = digestLength / 2;
-    }
 
+    // rfc4635#section-3.1, 4.:
+    // "MAC size" field is less than the larger of 10 (octets) and half
+    // the length of the hash function in use
+    int minDigestLength = Math.max(10, digestLength / 2);
     if (signature.length > digestLength) {
-      log.debug("BADSIG: signature too long");
+      log.debug(
+          "BADSIG: signature too long, expected: {}, actual: {}", digestLength, signature.length);
       return Rcode.BADSIG;
     } else if (signature.length < minDigestLength) {
-      log.debug("BADSIG: signature too short");
+      log.debug(
+          "BADSIG: signature too short, expected: {} of {}, actual: {}",
+          minDigestLength,
+          digestLength,
+          signature.length);
       return Rcode.BADSIG;
-    } else if (!verify(hmac, signature, true)) {
-      log.debug("BADSIG: signature verification");
-      return Rcode.BADSIG;
+    } else {
+      byte[] expectedSignature = hmac.doFinal();
+      if (!verify(expectedSignature, signature)) {
+        if (log.isDebugEnabled()) {
+          log.debug(
+              "BADSIG: signature verification failed, expected: {}, actual: {}",
+              base64.toString(expectedSignature),
+              base64.toString(signature));
+        }
+        return Rcode.BADSIG;
+      }
+    }
+
+    // validate time after the signature, as per
+    // https://tools.ietf.org/html/draft-ietf-dnsop-rfc2845bis-08#section-5.4.3
+    Instant now = clock.instant();
+    Duration delta = Duration.between(now, tsig.getTimeSigned()).abs();
+    if (delta.compareTo(tsig.getFudge()) > 0) {
+      log.debug(
+          "BADTIME failure, now {} +/- tsig {} > fudge {}",
+          now,
+          tsig.getTimeSigned(),
+          tsig.getFudge());
+      return Rcode.BADTIME;
     }
 
     m.tsigState = Message.TSIG_VERIFIED;
@@ -552,21 +626,43 @@ public class TSIG {
         + 8; // 2 byte error length, 6 byte max error field.
   }
 
+  private static void hmacAddSignature(Mac hmac, TSIGRecord tsig) {
+    byte[] signatureSize = DNSOutput.toU16(tsig.getSignature().length);
+    if (log.isTraceEnabled()) {
+      log.trace(hexdump.dump("TSIG-HMAC signature size", signatureSize));
+      log.trace(hexdump.dump("TSIG-HMAC signature", tsig.getSignature()));
+    }
+
+    hmac.update(signatureSize);
+    hmac.update(tsig.getSignature());
+  }
+
+  private static void writeTsigTimersVariables(Instant instant, Duration fudge, DNSOutput out) {
+    writeTsigTime(instant, out);
+    out.writeU16((int) fudge.getSeconds());
+  }
+
+  private static void writeTsigTime(Instant instant, DNSOutput out) {
+    long time = instant.getEpochSecond();
+    int timeHigh = (int) (time >> 32);
+    long timeLow = time & 0xFFFFFFFFL;
+    out.writeU16(timeHigh);
+    out.writeU32(timeLow);
+  }
+
   public static class StreamVerifier {
     /** A helper class for verifying multiple message responses. */
-    private TSIG key;
+    private final TSIG key;
 
-    private Mac verifier;
     private int nresponses;
     private int lastsigned;
     private TSIGRecord lastTSIG;
 
     /** Creates an object to verify a multiple message response */
-    public StreamVerifier(TSIG tsig, TSIGRecord old) {
+    public StreamVerifier(TSIG tsig, TSIGRecord queryTsig) {
       key = tsig;
-      verifier = tsig.hmac;
       nresponses = 0;
-      lastTSIG = old;
+      lastTSIG = queryTsig;
     }
 
     /**
@@ -583,80 +679,29 @@ public class TSIG {
       TSIGRecord tsig = m.getTSIG();
 
       nresponses++;
-
       if (nresponses == 1) {
         int result = key.verify(m, b, lastTSIG);
-        if (result == Rcode.NOERROR) {
-          byte[] signature = tsig.getSignature();
-          DNSOutput out = new DNSOutput();
-          out.writeU16(signature.length);
-          verifier.update(out.toByteArray());
-          verifier.update(signature);
-        }
         lastTSIG = tsig;
         return result;
       }
 
       if (tsig != null) {
-        m.getHeader().decCount(Section.ADDITIONAL);
-      }
-      byte[] header = m.getHeader().toWire();
-      if (tsig != null) {
-        m.getHeader().incCount(Section.ADDITIONAL);
-      }
-      verifier.update(header);
-
-      int len;
-      if (tsig == null) {
-        len = b.length - header.length;
-      } else {
-        len = m.tsigstart - header.length;
-      }
-      verifier.update(b, header.length, len);
-
-      if (tsig != null) {
+        int result = key.verify(m, b, lastTSIG, false);
         lastsigned = nresponses;
         lastTSIG = tsig;
+        return result;
       } else {
         boolean required = nresponses - lastsigned >= 100;
         if (required) {
+          log.debug("FORMERR: missing required signature on {}th message", nresponses);
           m.tsigState = Message.TSIG_FAILED;
           return Rcode.FORMERR;
         } else {
+          log.trace("Intermediate message {} without signature", nresponses);
           m.tsigState = Message.TSIG_INTERMEDIATE;
           return Rcode.NOERROR;
         }
       }
-
-      if (!tsig.getName().equals(key.name) || !tsig.getAlgorithm().equals(key.alg)) {
-        log.debug("BADKEY failure");
-        m.tsigState = Message.TSIG_FAILED;
-        return Rcode.BADKEY;
-      }
-
-      DNSOutput out = new DNSOutput();
-      long time = tsig.getTimeSigned().getEpochSecond();
-      int timeHigh = (int) (time >> 32);
-      long timeLow = time & 0xFFFFFFFFL;
-      out.writeU16(timeHigh);
-      out.writeU32(timeLow);
-      out.writeU16((int) tsig.getFudge().getSeconds());
-      verifier.update(out.toByteArray());
-
-      if (!TSIG.verify(verifier, tsig.getSignature())) {
-        log.debug("BADSIG failure");
-        m.tsigState = Message.TSIG_FAILED;
-        return Rcode.BADSIG;
-      }
-
-      verifier.reset();
-      out = new DNSOutput();
-      out.writeU16(tsig.getSignature().length);
-      verifier.update(out.toByteArray());
-      verifier.update(tsig.getSignature());
-
-      m.tsigState = Message.TSIG_VERIFIED;
-      return Rcode.NOERROR;
     }
   }
 }

--- a/src/main/java/org/xbill/DNS/ZoneTransferIn.java
+++ b/src/main/java/org/xbill/DNS/ZoneTransferIn.java
@@ -499,11 +499,9 @@ public class ZoneTransferIn {
       byte[] in = client.recv();
       Message response = parseMessage(in);
       if (response.getHeader().getRcode() == Rcode.NOERROR && verifier != null) {
-        TSIGRecord tsigrec = response.getTSIG();
-
         int error = verifier.verify(response, in);
         if (error != Rcode.NOERROR) {
-          fail("TSIG failure");
+          fail("TSIG failure: " + Rcode.TSIGstring(error));
         }
       }
 

--- a/src/main/java/org/xbill/DNS/tools/dig.java
+++ b/src/main/java/org/xbill/DNS/tools/dig.java
@@ -148,7 +148,18 @@ public class dig {
             } else {
               key = argv[++arg];
             }
-            res.setTSIGKey(TSIG.fromString(key));
+
+            String[] parts = key.split("[:/]", 3);
+            switch (parts.length) {
+              case 2:
+                res.setTSIGKey(new TSIG(TSIG.HMAC_MD5, parts[0], parts[1]));
+                break;
+              case 3:
+                res.setTSIGKey(new TSIG(parts[0], parts[1], parts[2]));
+                break;
+              default:
+                throw new IllegalArgumentException("Invalid TSIG key specification");
+            }
             break;
 
           case 't':

--- a/src/main/java/org/xbill/DNS/tools/jnamed.java
+++ b/src/main/java/org/xbill/DNS/tools/jnamed.java
@@ -388,7 +388,7 @@ public class jnamed {
         header.setFlag(Flags.AA);
         addRRset(rrset.getName(), response, rrset, Section.ANSWER, FLAG_DNSSECOK);
         if (tsig != null) {
-          tsig.applyStream(response, qtsig, first);
+          tsig.apply(response, qtsig, first);
           qtsig = response.getTSIG();
         }
         first = false;

--- a/src/main/java/org/xbill/DNS/tools/update.java
+++ b/src/main/java/org/xbill/DNS/tools/update.java
@@ -126,7 +126,7 @@ public class update {
             if (res == null) {
               res = new SimpleResolver(server);
             }
-            res.setTSIGKey(new TSIG(keyname, keydata));
+            res.setTSIGKey(new TSIG(TSIG.HMAC_MD5, keyname, keydata));
             break;
           case "edns":
             if (res == null) {

--- a/src/main/java/org/xbill/DNS/tools/xfrin.java
+++ b/src/main/java/org/xbill/DNS/tools/xfrin.java
@@ -43,7 +43,7 @@ public class xfrin {
         if (index < 0) {
           usage("invalid key");
         }
-        key = new TSIG(s.substring(0, index), s.substring(index + 1));
+        key = new TSIG(TSIG.HMAC_MD5, s.substring(0, index), s.substring(index + 1));
       } else if (args[arg].equals("-s")) {
         server = args[++arg];
       } else if (args[arg].equals("-p")) {


### PR DESCRIPTION
- Remove duplicate code in generate/verify by adding a parameter
  for the difference between "full" and "intermediate" signatures.
- Handle truncated signatures in streams
- Move time validation as per draft-ietf-dnsop-rfc2845bis
- Add trace dump of signature input data

Closes #109