### PR TITLE
Support IPv4 mapped IPv6 address in AAAA record

### DIFF
--- a/src/main/java/org/xbill/DNS/AAAARecord.java
+++ b/src/main/java/org/xbill/DNS/AAAARecord.java
@@ -25,8 +25,8 @@ public class AAAARecord extends Record {
    */
   public AAAARecord(Name name, int dclass, long ttl, InetAddress address) {
     super(name, Type.AAAA, dclass, ttl);
-    if (Address.familyOf(address) != Address.IPv6) {
-      throw new IllegalArgumentException("invalid IPv6 address");
+    if (Address.familyOf(address) != Address.IPv4 && Address.familyOf(address) != Address.IPv6) {
+      throw new IllegalArgumentException("invalid IPv4/IPv6 address");
     }
     this.address = address.getAddress();
   }
@@ -52,13 +52,7 @@ public class AAAARecord extends Record {
     }
     if (addr.getAddress().length == 4) {
       // Deal with Java's broken handling of mapped IPv4 addresses.
-      StringBuilder sb = new StringBuilder("0:0:0:0:0:ffff:");
-      int high = ((address[12] & 0xFF) << 8) + (address[13] & 0xFF);
-      int low = ((address[14] & 0xFF) << 8) + (address[15] & 0xFF);
-      sb.append(Integer.toHexString(high));
-      sb.append(':');
-      sb.append(Integer.toHexString(low));
-      return sb.toString();
+      return "::ffff:" + addr.getHostAddress();
     }
     return addr.getHostAddress();
   }

--- a/src/test/java/org/xbill/DNS/AAAARecordTest.java
+++ b/src/test/java/org/xbill/DNS/AAAARecordTest.java
@@ -87,13 +87,9 @@ class AAAARecordTest {
   }
 
   @Test
-  void ctor_v4() {
-    try {
+  void ctor_v4() throws UnknownHostException {
       AAAARecord ar = new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.1.1"));
       assertEquals("::ffff:192.168.1.1", ar.rrToString());
-    } catch (UnknownHostException ignore) {
-
-    }
   }
 
   @Test

--- a/src/test/java/org/xbill/DNS/AAAARecordTest.java
+++ b/src/test/java/org/xbill/DNS/AAAARecordTest.java
@@ -85,14 +85,15 @@ class AAAARecordTest {
 
     // a relative name
     assertThrows(RelativeNameException.class, () -> new AAAARecord(m_rn, DClass.IN, m_ttl, m_addr));
+  }
 
-    // an IPv4 address
+  @Test
+  void ctor_v4() {
     try {
-      new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.0.1"));
-      fail("IllegalArgumentException not thrown");
-    } catch (IllegalArgumentException e) {
-    } catch (UnknownHostException e) {
-      fail(e.getMessage());
+      AAAARecord ar = new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.1.1"));
+      assertEquals("::ffff:192.168.1.1", ar.rrToString());
+    } catch (UnknownHostException ignore){
+
     }
   }
 

--- a/src/test/java/org/xbill/DNS/AAAARecordTest.java
+++ b/src/test/java/org/xbill/DNS/AAAARecordTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -92,7 +91,7 @@ class AAAARecordTest {
     try {
       AAAARecord ar = new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.1.1"));
       assertEquals("::ffff:192.168.1.1", ar.rrToString());
-    } catch (UnknownHostException ignore){
+    } catch (UnknownHostException ignore) {
 
     }
   }

--- a/src/test/java/org/xbill/DNS/AAAARecordTest.java
+++ b/src/test/java/org/xbill/DNS/AAAARecordTest.java
@@ -88,8 +88,8 @@ class AAAARecordTest {
 
   @Test
   void ctor_v4() throws UnknownHostException {
-      AAAARecord ar = new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.1.1"));
-      assertEquals("::ffff:192.168.1.1", ar.rrToString());
+    AAAARecord ar = new AAAARecord(m_an, DClass.IN, m_ttl, InetAddress.getByName("192.168.1.1"));
+    assertEquals("::ffff:192.168.1.1", ar.rrToString());
   }
 
   @Test


### PR DESCRIPTION
1. let AAAARecord support IPv4 Address.
2. use ::ffff:x.x.x.x instead of 0:0:0:0:ffff:xx:xx, more readable