### PR TITLE
Allow for an unknown content length.

### DIFF
--- a/src/main/java/org/xbill/DNS/DohResolver.java
+++ b/src/main/java/org/xbill/DNS/DohResolver.java
@@ -252,7 +252,8 @@ public final class DohResolver implements Resolver {
     if (contentLength > -1) {
       responseBytes = new byte[contentLength];
 
-      // As bytes are read the available space in responseBytes reduces, so the 3rd parameter should reduce accordingly.
+      // As bytes are read the available space in responseBytes reduces, so the 3rd parameter should
+      // reduce accordingly.
       while ((r = is.read(responseBytes, offset, responseBytes.length - offset)) > 0) {
         offset += r;
       }
@@ -261,7 +262,8 @@ public final class DohResolver implements Resolver {
       // The response length is unknown, so read until we get a response of -1
       responseBytes = new byte[MAX_DOH_RESPONSE_SIZE];
 
-      // As bytes are read the available space in responseBytes reduces, so the 3rd parameter should reduce accordingly.
+      // As bytes are read the available space in responseBytes reduces, so the 3rd parameter should
+      // reduce accordingly.
       while ((r = is.read(responseBytes, offset, responseBytes.length - offset)) > 0) {
         offset += r;
       }


### PR DESCRIPTION
My DoH service works fine when accessed directly, but when it is behind an API gateway the response content length is unknown, so `conn.getContentLength()` returns `-1` which causes an exception to be thrown.

I have 2 suggested changes here:

1. When the content length is unknown, just create a fixed size buffer for the response. I have chosen a maximum size that seems sensible to me, and I know I could have made it dynamic, but I think even in that case there would still be a need for a sensible maximum buffer size. I can change this if needed.
1. When reading from the connection stream, it is always trying to read `responseBytes.length` bytes, but if it has already read some bytes then there will be no room for that number of bytes, so I have used the `offset` to reduce this as bytes are read into the buffer. I realise that if the content length is known then it won't read more than the expected number of bytes, but in the case when the length is not known it will be possible to read more bytes than the allocated buffer size, hence the check.

I have tested this against `https://dns.google/dns-query` which does return a valid content length, as well as my own service behind an API gateway which returns -1 for the content length, and it succeeds in both cases.

