### PR TITLE
Fix bug with SVCB/HTTPS parsing of master file format

### DIFF
--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -728,6 +728,7 @@ abstract class SVCBBase extends Record {
       param.fromString(valueStr);
       svcParams.put(key, param);
     }
+    st.unget();
 
     if (svcPriority > 0 && svcParams.isEmpty()) {
       throw new TextParseException(


### PR DESCRIPTION
Fix bug with parsing SVCB/HTTPS records from text where the Tokenizer is not properly reset at the end of the line.  The individual record parsing works correctly, but this was breaking the parsing of master zone files with SVCB or HTTPS records in them.