### PR TITLE
began experimenting with DNSSession

### DIFF
--- a/src/main/java/org/xbill/DNS/DNSSession.java
+++ b/src/main/java/org/xbill/DNS/DNSSession.java
@@ -1,0 +1,137 @@
+package org.xbill.DNS;
+
+import static java.lang.String.format;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.xbill.DNS.exceptions.AdditionalDetail;
+import org.xbill.DNS.exceptions.InvalidZoneDataException;
+import org.xbill.DNS.exceptions.LookupFailedException;
+import org.xbill.DNS.exceptions.RedirectOverflowException;
+import org.xbill.DNS.exceptions.ServerFailedException;
+
+/**
+ * DNSSession provides facilities to make DNS Queries. A DNSSession is intended to be long lived,
+ * and it's behaviour can be modified by calling the setter methods.
+ */
+public class DNSSession {
+  private static final int DEFAULT_MAX_ITERATIONS = 16;
+
+  private final Resolver resolver;
+  private volatile int maxRedirects = DEFAULT_MAX_ITERATIONS;
+
+  //  TODO: properties we want to support
+  //    Cache cache,
+  //    List<Name> searchPath,
+  //    int ndots,
+  //    boolean cycleResults,
+  //    int credibility,
+  //  ) {
+
+  /**
+   * Construct a DNSSession using the provided Resolver to lookup records.
+   *
+   * @param resolver the Resolver instance to backing this DNSSession.
+   */
+  DNSSession(Resolver resolver) {
+    this.resolver = resolver;
+  }
+
+  /**
+   * Sets the maximum number of CNAME or DNAME redirects allowed before lookups with fail with
+   * RedirectOverflowException
+   *
+   * @param maxRedirects the maximum number of allowed redirections.
+   */
+  public void setMaxRedirects(int maxRedirects) {
+    this.maxRedirects = maxRedirects;
+  }
+
+  /**
+   * Make an asynchronous lookup of the provided name.
+   *
+   * @param name the name to look up
+   * @param type the type to look up, values should correspond to constants in Type
+   * @param dclass the class to look up, values should correspond to constants in DClass
+   * @return A completion stage what will yield the eventual lookup
+   */
+  public CompletionStage<LookupResult> lookupAsync(Name name, int type, int dclass) {
+    Record question = Record.newRecord(name, type, dclass);
+    Message query = Message.newQuery(question);
+
+    return resolver.sendAsync(query).thenCompose(this::resolveRedirects);
+  }
+
+  private CompletionStage<LookupResult> resolveRedirects(Message response) {
+    CompletableFuture<LookupResult> future = new CompletableFuture<>();
+    maybeFollowRedirect(response, 1, future);
+    return future;
+  }
+
+  private void maybeFollowRedirect(
+      Message response, int redirectCount, CompletableFuture<LookupResult> future) {
+    try {
+      if (redirectCount > maxRedirects) {
+        throw new RedirectOverflowException(
+            format("Refusing to follow more than %s redirects", maxRedirects));
+      }
+
+      List<Record> allAnswers = response.getSection(Section.ANSWER);
+      LookupResult result = dealWithEmptyAnswer(allAnswers, response.getHeader().getRcode());
+      if (result != null) {
+        future.complete(result);
+        return;
+      }
+      Record firstAnswer = allAnswers.get(0);
+
+      if (firstAnswer.getType() == Type.DNAME || firstAnswer.getType() == Type.CNAME) {
+        resolver
+            .sendAsync(Message.newQuery(buildRedirectQuery(response)))
+            .thenAccept(m -> maybeFollowRedirect(m, redirectCount + 1, future));
+      } else {
+        future.complete(new LookupResult(allAnswers, null));
+      }
+    } catch (LookupFailedException e) {
+      future.completeExceptionally(e);
+    }
+  }
+
+  private Record buildRedirectQuery(Message response) {
+    List<Record> answer = response.getSection(Section.ANSWER);
+    Record firstAnswer = answer.get(0);
+    if (answer.size() != 1) {
+      throw new InvalidZoneDataException("Multiple CNAME RRs not allowed, SEE RFC1034 3.6.2");
+    }
+    Record question = response.getQuestion();
+    if (firstAnswer.getType() == Type.CNAME) {
+      return Record.newRecord(
+          ((CNAMERecord) firstAnswer).getTarget(), question.getType(), question.getDClass());
+    }
+    assert firstAnswer.getType() == Type.DNAME;
+    try {
+      Name name = question.getName().fromDNAME((DNAMERecord) firstAnswer);
+      return Record.newRecord(name, question.getType(), question.getDClass());
+    } catch (NameTooLongException e) {
+      throw new InvalidZoneDataException(
+          "DNAME redirect would result in a name that would be too long");
+    }
+  }
+
+  /** Returns a LookupResult if there was one of the empty result one, else null. */
+  private LookupResult dealWithEmptyAnswer(List<Record> answer, int rcode) {
+    if (answer.isEmpty()) {
+      switch (rcode) {
+        case Rcode.NXDOMAIN:
+          return new LookupResult(answer, AdditionalDetail.NXDOMAIN);
+        case Rcode.NXRRSET:
+          return new LookupResult(answer, AdditionalDetail.NXRRSET);
+        case Rcode.SERVFAIL:
+          throw new ServerFailedException();
+        default:
+          throw new LookupFailedException(format("Unknown non-success error code %d", rcode));
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/xbill/DNS/LookupResult.java
+++ b/src/main/java/org/xbill/DNS/LookupResult.java
@@ -1,0 +1,55 @@
+package org.xbill.DNS;
+
+import java.util.List;
+import java.util.Objects;
+import org.xbill.DNS.exceptions.AdditionalDetail;
+import org.xbill.DNS.exceptions.LookupFailedException;
+
+/** LookupResult instances holds the result of a successful lookup operation. */
+public class LookupResult {
+  private final List<Record> records;
+  private final AdditionalDetail additionalDetail;
+
+  /**
+   * Construct an instance with the provided records.
+   *
+   * @param records a list of records to return, or null if there was no response
+   * @param additionalDetail additional detail on this response, such as the reason for records
+   *     being null.
+   */
+  public LookupResult(List<Record> records, AdditionalDetail additionalDetail) {
+    this.records = records;
+    this.additionalDetail = additionalDetail;
+  }
+
+  /**
+   * An unmodifiable list of records that this instance wraps
+   *
+   * @return an unmodifiable List of Record instances.
+   */
+  public List<Record> get() throws LookupFailedException {
+    return records;
+  }
+
+  public AdditionalDetail getAdditionalDetail() {
+    return additionalDetail;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LookupResult that = (LookupResult) o;
+    return records.equals(that.records) && additionalDetail == that.additionalDetail;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(records, additionalDetail);
+  }
+
+  @Override
+  public String toString() {
+    return "LookupResult{" + "records=" + records + ", additionalDetail=" + additionalDetail + '}';
+  }
+}

--- a/src/main/java/org/xbill/DNS/exceptions/AdditionalDetail.java
+++ b/src/main/java/org/xbill/DNS/exceptions/AdditionalDetail.java
@@ -1,0 +1,14 @@
+package org.xbill.DNS.exceptions;
+
+public enum AdditionalDetail {
+  /**
+   * An empty response was returned because the resolver returned the NXDOMAIN status code, meaning
+   * that there was no dns data associated with the provided name.
+   */
+  NXDOMAIN,
+  /**
+   * An empty response was returned because although there was a response for the specified name it
+   * was not of the Type requested.
+   */
+  NXRRSET,
+}

--- a/src/main/java/org/xbill/DNS/exceptions/InvalidZoneDataException.java
+++ b/src/main/java/org/xbill/DNS/exceptions/InvalidZoneDataException.java
@@ -1,0 +1,7 @@
+package org.xbill.DNS.exceptions;
+
+public class InvalidZoneDataException extends LookupFailedException {
+  public InvalidZoneDataException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/xbill/DNS/exceptions/LookupFailedException.java
+++ b/src/main/java/org/xbill/DNS/exceptions/LookupFailedException.java
@@ -1,0 +1,12 @@
+package org.xbill.DNS.exceptions;
+
+/** A base class for all types of things that might fail when making a DNS lookup. */
+public class LookupFailedException extends RuntimeException {
+  public LookupFailedException() {
+    super();
+  }
+
+  public LookupFailedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/xbill/DNS/exceptions/RedirectOverflowException.java
+++ b/src/main/java/org/xbill/DNS/exceptions/RedirectOverflowException.java
@@ -1,0 +1,7 @@
+package org.xbill.DNS.exceptions;
+
+public class RedirectOverflowException extends LookupFailedException {
+  public RedirectOverflowException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/xbill/DNS/exceptions/ServerFailedException.java
+++ b/src/main/java/org/xbill/DNS/exceptions/ServerFailedException.java
@@ -1,0 +1,7 @@
+package org.xbill.DNS.exceptions;
+
+/**
+ * Represents a server failure, that the upstream server responding to the request returned a
+ * SERVFAIL status.
+ */
+public class ServerFailedException extends LookupFailedException {}

--- a/src/test/java/org/xbill/DNS/DNSSessionTest.java
+++ b/src/test/java/org/xbill/DNS/DNSSessionTest.java
@@ -1,0 +1,223 @@
+package org.xbill.DNS;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.xbill.DNS.DClass.IN;
+import static org.xbill.DNS.LookupTest.DUMMY_NAME;
+import static org.xbill.DNS.LookupTest.LONG_LABEL;
+import static org.xbill.DNS.LookupTest.answer;
+import static org.xbill.DNS.LookupTest.fail;
+import static org.xbill.DNS.Type.A;
+import static org.xbill.DNS.Type.CNAME;
+import static org.xbill.DNS.exceptions.AdditionalDetail.NXDOMAIN;
+import static org.xbill.DNS.exceptions.AdditionalDetail.NXRRSET;
+
+import java.net.InetAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.xbill.DNS.exceptions.InvalidZoneDataException;
+import org.xbill.DNS.exceptions.LookupFailedException;
+import org.xbill.DNS.exceptions.RedirectOverflowException;
+import org.xbill.DNS.exceptions.ServerFailedException;
+
+class DNSSessionTest {
+
+  @Mock Resolver mockResolver = mock(Resolver.class);
+
+  @AfterEach
+  public void after() {
+    verifyNoMoreInteractions(mockResolver);
+  }
+
+  @Test
+  public void lookupAsync_absoluteQuery() throws InterruptedException, ExecutionException {
+    wireUpMockResolver(mockResolver, query -> answer(query, name -> LOOPBACK_A));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture =
+        dnsSession.lookupAsync(Name.fromConstantString("a.b."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("a.b."))), result.get());
+
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_simpleCnameRedirect() throws Exception {
+    Function<Name, Record> nameToRecord =
+        name -> name("cname.r.").equals(name) ? cname("cname.r.", "a.b.") : LOOPBACK_A;
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("cname.r."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("a.b."))), result.get());
+    verify(mockResolver, times(2)).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_simpleDnameRedirect() throws Exception {
+    Function<Name, Record> nameToRecord =
+        n -> name("x.y.to.dname.").equals(n) ? dname("to.dname.", "to.a.") : LOOPBACK_A;
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+
+    CompletionStage<LookupResult> resultFuture =
+        dnsSession.lookupAsync(name("x.y.to.dname."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("x.y.to.a."))), result.get());
+    verify(mockResolver, times(2)).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_redirectLoop() {
+    Function<Name, Record> nameToRecord =
+        name -> name("a.b.").equals(name) ? cname("a.", "b.") : cname("b.", "a.");
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    dnsSession.setMaxRedirects(2);
+
+    CompletionStage<LookupResult> resultFuture =
+        dnsSession.lookupAsync(name("first.example.com."), A, IN);
+
+    assertThrowsCause(
+        RedirectOverflowException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver, times(3)).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_NXDOMAIN() throws Exception {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NXDOMAIN));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("a.b."), A, IN);
+
+    assertEquals(new LookupResult(emptyList(), NXDOMAIN), resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_SERVFAIL() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.SERVFAIL));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(ServerFailedException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_unknownFailure() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NOTIMP));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(LookupFailedException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_NXRRSET() throws Exception {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NXRRSET));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("a.b."), A, IN);
+
+    assertEquals(new LookupResult(emptyList(), NXRRSET), resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_TooLongNameDNAME() {
+    wireUpMockResolver(
+        mockResolver, q -> answer(q, n -> dname("to.dname.", format("%s.to.a.", LONG_LABEL))));
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    Name toLookup = name(format("%s.%s.%s.to.dname.", LONG_LABEL, LONG_LABEL, LONG_LABEL));
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(toLookup, A, IN);
+
+    assertThrowsCause(
+        InvalidZoneDataException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  public void lookupAsync_MultipleCNAMEs() {
+    // According to https://docstore.mik.ua/orelly/networking_2ndEd/dns/ch10_07.htm this is
+    // apparently something
+    // that BIND 4 did.
+    wireUpMockResolver(mockResolver, DNSSessionTest::multipleCNAMEs);
+
+    DNSSession dnsSession = new DNSSession(mockResolver);
+    CompletionStage<LookupResult> resultFuture = dnsSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(
+        InvalidZoneDataException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  private static Message multipleCNAMEs(Message query) {
+    Message answer = new Message(query.getHeader().getID());
+    Record question = query.getQuestion();
+    answer.addRecord(question, Section.QUESTION);
+    answer.addRecord(
+        new CNAMERecord(question.getName(), CNAME, IN, name("target1.")), Section.ANSWER);
+    answer.addRecord(
+        new CNAMERecord(question.getName(), CNAME, IN, name("target2.")), Section.ANSWER);
+    return answer;
+  }
+
+  private static final ARecord LOOPBACK_A =
+      new ARecord(DUMMY_NAME, IN, 0, InetAddress.getLoopbackAddress());
+
+  private static CNAMERecord cname(String name, String target) {
+    return new CNAMERecord(name(name), IN, 0, name(target));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static DNAMERecord dname(String name, String target) {
+    return new DNAMERecord(name(name), IN, 0, name(target));
+  }
+
+  private static Name name(String name) {
+    return Name.fromConstantString(name);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private <T extends Throwable> void assertThrowsCause(Class<T> ex, Executable executable) {
+    Throwable outerException = assertThrows(Throwable.class, executable);
+    assertEquals(ex, outerException.getCause().getClass());
+  }
+
+  private void wireUpMockResolver(Resolver mockResolver, Function<Message, Message> handler) {
+    when(mockResolver.sendAsync(any(Message.class)))
+        .thenAnswer(
+            invocation -> {
+              Message query = invocation.getArgument(0);
+              return CompletableFuture.completedFuture(handler.apply(query));
+            });
+  }
+}

--- a/src/test/java/org/xbill/DNS/LookupTest.java
+++ b/src/test/java/org/xbill/DNS/LookupTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 package org.xbill.DNS;
 
+import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,7 +16,6 @@ import java.io.InterruptedIOException;
 import java.net.InetAddress;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +24,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class LookupTest {
-  public static final Name DUMMY_NAME = Name.fromConstantString("ignored.");
+  public static final Name DUMMY_NAME = Name.fromConstantString("to.be.replaced.");
+  public static final String LONG_LABEL =
+      IntStream.range(0, 63).mapToObj(i -> "a").collect(joining());
+
   private Resolver mockResolver;
 
   @BeforeEach
@@ -243,11 +246,9 @@ public class LookupTest {
   void testRun_concatenatedNameTooLong() throws Exception {
     wireUpMockResolver(mockResolver, this::simpleAnswer);
 
-    String longName = IntStream.range(0, 63).mapToObj(i -> "a").collect(Collectors.joining());
-
-    Lookup lookup = makeLookupWithResolver(mockResolver, longName);
+    Lookup lookup = makeLookupWithResolver(mockResolver, LONG_LABEL);
     // search path has a suffix that will make the combined name too long
-    lookup.setSearchPath(String.format("%s.%s.%s", longName, longName, longName));
+    lookup.setSearchPath(String.format("%s.%s.%s", LONG_LABEL, LONG_LABEL, LONG_LABEL));
     Record[] results = lookup.run();
 
     ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -257,7 +258,7 @@ public class LookupTest {
     // ignored, and resolution falls back to converting longName to an absolute name and querying
     // that
     assertEquals(
-        Record.newRecord(Name.fromConstantString(longName + "."), Type.A, DClass.IN, 0L),
+        Record.newRecord(Name.fromConstantString(LONG_LABEL + "."), Type.A, DClass.IN, 0L),
         messageCaptor.getValue().getSection(Section.QUESTION).get(0));
 
     assertEquals(1, results.length);
@@ -287,7 +288,7 @@ public class LookupTest {
   }
 
   @Test
-  void testLookup_constructorFailsWithMetaTypes() throws TextParseException {
+  void testLookup_constructorFailsWithMetaTypes() {
     assertThrows(IllegalArgumentException.class, () -> new Lookup("example.com.", Type.OPT));
   }
 
@@ -329,7 +330,7 @@ public class LookupTest {
     }
   }
 
-  private Message fail(Message query, int code) {
+  static Message fail(Message query, int code) {
     Message answer = new Message(query.getHeader().getID());
     answer.addRecord(query.getQuestion(), Section.QUESTION);
     answer.getHeader().setRcode(code);
@@ -341,7 +342,7 @@ public class LookupTest {
     return answer(query, name -> r);
   }
 
-  private Message answer(Message query, Function<Name, Record> recordMaker) {
+  static Message answer(Message query, Function<Name, Record> recordMaker) {
     Message answer = new Message(query.getHeader().getID());
     answer.addRecord(query.getQuestion(), Section.QUESTION);
     Name questionName = query.getQuestion().getName();
@@ -349,7 +350,10 @@ public class LookupTest {
     if (response == null) {
       answer.getHeader().setRcode(Rcode.NXDOMAIN);
     } else {
-      answer.addRecord(response.withName(query.getQuestion().getName()), Section.ANSWER);
+      if (DUMMY_NAME.equals(response.getName())) {
+        response = response.withName(query.getQuestion().getName());
+      }
+      answer.addRecord(response, Section.ANSWER);
     }
     return answer;
   }


### PR DESCRIPTION
I have started experimenting with an asynchronous lookup mechanism. Please note that this is a draft and not not feature complete. I just want to give the opportunity to gather some early feedback. In particular I am curious to to hear about:

* The name `DNSSession` for the new long lived API endpoint. Session is kind of vague on purpose, to allow it to have other public methods in the future that interact with DNS servers. I want to avoid `Session` because of the inconvenience of having it clash with for example the Session classes in the Neo4j or Cassandra.
* What do we think about putting an exception hierarchy in a separate module? My main reason for going there is that the org.xbill.DNS module is pretty crowded, but this is a weak preference.

The idea is to implement the following:
* Add aliases to QueryResult
* caching
* search path expansion
*  ndots handling
* the cycleResults feature
* a configurable minimum credibility requirement

Once this is in place, this query implementation would reach feature parity with Lookup.run() and we could replace that one with this without changing the public API (besides making it Deprecated, possibly).