### PR TITLE
Introduce an asynchronous lookup API

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.java.source>8</sonar.java.source>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <delombok.output>${project.build.directory}/generated-sources/delombok</delombok.output>
     </properties>
 
     <build>
@@ -141,6 +142,7 @@
                     <windowtitle>dnsjava documentation</windowtitle>
                     <footer/>
                     <doclint>none</doclint>
+                    <sourcepath>${delombok.output}</sourcepath>
                 </configuration>
             </plugin>
 
@@ -302,6 +304,25 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>1.18.18.0</version>
+                <configuration>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    <addOutputDirectory>false</addOutputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -360,6 +381,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
@@ -395,7 +422,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <excludePackageNames>*.spi.*</excludePackageNames>
+                            <excludePackageNames>*.spi</excludePackageNames>
+                            <sourcepath>${delombok.output}</sourcepath>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/org/xbill/DNS/lookup/InvalidZoneDataException.java
+++ b/src/main/java/org/xbill/DNS/lookup/InvalidZoneDataException.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+/**
+ * Sometimes DNS zone data involved in the lookup might be violating specifications. For example, a
+ * DNAME expansion might result in names that are too long or a query response might hold multiple
+ * CNAME records.
+ */
+public class InvalidZoneDataException extends LookupFailedException {
+  public InvalidZoneDataException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/LookupFailedException.java
+++ b/src/main/java/org/xbill/DNS/lookup/LookupFailedException.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+import org.xbill.DNS.Name;
+
+/** A base class for all types of things that might fail when making a DNS lookup. */
+public class LookupFailedException extends RuntimeException {
+  private final Name name;
+  private final int type;
+
+  public LookupFailedException() {
+    super();
+    name = null;
+    type = 0;
+  }
+
+  public LookupFailedException(String message) {
+    super(message);
+    name = null;
+    type = 0;
+  }
+
+  /**
+   * Construct a LookupFailedException that also specifies the name and type of the lookup that
+   * failed.
+   *
+   * @param name the name that caused the failure.
+   * @param type the type that caused the failure.
+   */
+  public LookupFailedException(Name name, int type) {
+    this.name = name;
+    this.type = type;
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/LookupResult.java
+++ b/src/main/java/org/xbill/DNS/lookup/LookupResult.java
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+
+/** LookupResult instances holds the result of a successful lookup operation. */
+@ToString
+@EqualsAndHashCode
+public final class LookupResult {
+  /** An unmodifiable list of records that this instance wraps, may not be null but can be empty */
+  @Getter private final List<Record> records;
+  /**
+   * In the case of CNAME or DNAME indirection, this property contains the original name as well as
+   * any intermediate redirect targets except the last one. For example, if X is a CNAME pointing to
+   * Y which is a CNAME pointing to Z which has an A record, aliases will hold X and Y after
+   * successful lookup.
+   */
+  @Getter private List<Name> aliases;
+
+  /**
+   * Construct an instance with the provided records and, in the case of a CNAME or DNAME
+   * indirection a List of aliases.
+   *
+   * @param records a list of records to return.
+   * @param aliases a list of aliases discovered during lookup, or null if there was no indirection.
+   */
+  public LookupResult(List<Record> records, List<Name> aliases) {
+    this.records = Collections.unmodifiableList(new ArrayList<>(records));
+    if (aliases != null) {
+      this.aliases = Collections.unmodifiableList(new ArrayList<>(aliases));
+    }
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/LookupSession.java
+++ b/src/main/java/org/xbill/DNS/lookup/LookupSession.java
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import org.xbill.DNS.CNAMERecord;
+import org.xbill.DNS.Cache;
+import org.xbill.DNS.Credibility;
+import org.xbill.DNS.DClass;
+import org.xbill.DNS.DNAMERecord;
+import org.xbill.DNS.Message;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.NameTooLongException;
+import org.xbill.DNS.Rcode;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.Resolver;
+import org.xbill.DNS.Section;
+import org.xbill.DNS.SetResponse;
+import org.xbill.DNS.Type;
+
+/**
+ * LookupSession provides facilities to make DNS Queries. A LookupSession is intended to be long
+ * lived, and it's behaviour can be configured using the properties of the LookupSessionBuilder
+ * instance returned by the builder() method.
+ */
+@Builder
+public class LookupSession {
+  public static final int DEFAULT_MAX_ITERATIONS = 16;
+  public static final int DEFAULT_NDOTS = 1;
+  /** The {@link Resolver} to use to look up records. */
+  @NonNull private final Resolver resolver;
+  /**
+   * Sets the maximum number of CNAME or DNAME redirects allowed before lookups with fail with
+   * {@link RedirectOverflowException}. Defaults to {@value
+   * org.xbill.DNS.lookup.LookupSession#DEFAULT_MAX_ITERATIONS}.
+   */
+  @Builder.Default private final int maxRedirects = DEFAULT_MAX_ITERATIONS;
+  /**
+   * Sets the threshold for the number of dots which must appear in a name before it is considered
+   * absolute. The default is {@value org.xbill.DNS.lookup.LookupSession#DEFAULT_NDOTS}, meaning
+   * that if there are any dots in a name, the name will be tried first as an absolute name.
+   */
+  @Builder.Default private final int ndots = DEFAULT_NDOTS;
+
+  /** Configures the search path used to look up relative names with less than ndots dots. */
+  @Singular("searchPath")
+  private final List<Name> searchPath;
+
+  /**
+   * If set to {@code true}, cached results with multiple records will be returned with the starting
+   * point shifted one step per request.
+   */
+  @Builder.Default private final boolean cycleResults = false;
+
+  /**
+   * Configures the Cache instances to be used for lookups for the different {@link DClass} values.
+   */
+  @Singular("cache")
+  private final Map<Integer, Cache> caches;
+
+  /**
+   * A builder for {@link LookupSession} instances where functionality is mostly generated as
+   * described in the <a href="https://projectlombok.org/features/Builder">Lombok Builder</a>
+   * documentation. An instance of this class is obtained by calling {@link LookupSession#builder()}
+   * and configured using the methods with names corresponding to the different properties. Once
+   * fully configured, a {@link LookupSession} instance is obtained by calling {@link
+   * LookupSessionBuilder#build()} on the builder instance.
+   */
+  public static class LookupSessionBuilder {
+    void preBuild() {
+      // note that this transform is idempotent, as concatenating an already absolute Name with root
+      // is a noop.
+      if (searchPath != null) {
+        this.searchPath =
+            searchPath.stream()
+                .map(
+                    name -> {
+                      try {
+                        return Name.concatenate(name, Name.root);
+                      } catch (NameTooLongException e) {
+                        throw new IllegalArgumentException("Search path name too long");
+                      }
+                    })
+                .collect(Collectors.toCollection(ArrayList::new));
+      }
+    }
+  }
+
+  /** Returns a new {@link LookupSessionBuilder} instance. */
+  public static LookupSessionBuilder builder() {
+    return new LookupSessionBuilder() {
+      @Override
+      public LookupSession build() {
+        preBuild();
+        return super.build();
+      }
+    };
+  }
+
+  /**
+   * Make an asynchronous lookup of the provided name.
+   *
+   * @param name the name to look up.
+   * @param type the type to look up, values should correspond to constants in {@link Type}.
+   * @param dclass the class to look up, values should correspond to constants in {@link DClass}.
+   * @return A {@link CompletionStage} what will yield the eventual lookup result.
+   */
+  public CompletionStage<LookupResult> lookupAsync(Name name, int type, int dclass) {
+    CompletableFuture<LookupResult> future = new CompletableFuture<>();
+    lookupUntilSuccess(expandName(name).iterator(), type, dclass, future);
+    return future;
+  }
+
+  /**
+   * Generate a stream of names according to the search path application semantics. The semantics of
+   * this is a bit odd, but they are inherited from Lookup.java. Note that the stream returned is
+   * never empty, as it will at the very least always contain {@code name}.
+   */
+  Stream<Name> expandName(Name name) {
+    if (name.isAbsolute()) {
+      return Stream.of(name);
+    }
+    Stream<Name> fromSearchPath =
+        Stream.concat(
+            searchPath.stream()
+                .map(searchSuffix -> safeConcat(name, searchSuffix))
+                .filter(Objects::nonNull),
+            Stream.of(safeConcat(name, Name.root)));
+
+    if (name.labels() > ndots) {
+      return Stream.concat(Stream.of(safeConcat(name, Name.root)), fromSearchPath);
+    }
+    return fromSearchPath;
+  }
+
+  private static Name safeConcat(Name name, Name suffix) {
+    try {
+      return Name.concatenate(name, suffix);
+    } catch (NameTooLongException e) {
+      return null;
+    }
+  }
+
+  private void lookupUntilSuccess(
+      Iterator<Name> names, int type, int dclass, CompletableFuture<LookupResult> future) {
+
+    Record query = Record.newRecord(names.next(), type, dclass);
+    lookupWithCache(query, null)
+        .thenCompose(answer -> resolveRedirects(answer, query))
+        .whenComplete(
+            (result, ex) -> {
+              Throwable cause = ex == null ? null : ex.getCause();
+              if (cause instanceof NoSuchDomainException || cause instanceof NoSuchRRSetException) {
+                if (names.hasNext()) {
+                  lookupUntilSuccess(names, type, dclass, future);
+                } else {
+                  future.completeExceptionally(cause);
+                }
+              } else if (cause != null) {
+                future.completeExceptionally(cause);
+              } else {
+                future.complete(result);
+              }
+            });
+  }
+
+  private CompletionStage<LookupResult> lookupWithCache(Record queryRecord, List<Name> aliases) {
+    return Optional.ofNullable(caches.get(queryRecord.getDClass()))
+        .map(c -> c.lookupRecords(queryRecord.getName(), queryRecord.getType(), Credibility.NORMAL))
+        .map(setResponse -> setResponseToMessageFuture(setResponse, queryRecord))
+        .orElseGet(() -> lookupWithResolver(queryRecord, aliases));
+  }
+
+  private CompletionStage<LookupResult> lookupWithResolver(Record queryRecord, List<Name> aliases) {
+    return resolver
+        .sendAsync(Message.newQuery(queryRecord))
+        .thenApply(this::maybeAddToCache)
+        .thenApply(answer -> buildResult(answer, aliases, queryRecord));
+  }
+
+  private Message maybeAddToCache(Message message) {
+    Optional.ofNullable(caches.get(message.getQuestion().getDClass()))
+        .ifPresent(cache -> cache.addMessage(message));
+    return message;
+  }
+
+  private CompletionStage<LookupResult> setResponseToMessageFuture(
+      SetResponse setResponse, Record queryRecord) {
+    if (setResponse.isNXDOMAIN()) {
+      return completeExceptionally(
+          new NoSuchDomainException(queryRecord.getName(), queryRecord.getType()));
+    }
+    if (setResponse.isNXRRSET()) {
+      return completeExceptionally(
+          new NoSuchRRSetException(queryRecord.getName(), queryRecord.getType()));
+    }
+    if (setResponse.isSuccessful()) {
+      List<Record> records =
+          setResponse.answers().stream()
+              .flatMap(rrset -> rrset.rrs(cycleResults).stream())
+              .collect(Collectors.toList());
+      return CompletableFuture.completedFuture(new LookupResult(records, null));
+    }
+    return null;
+  }
+
+  private <T extends LookupFailedException> CompletionStage<LookupResult> completeExceptionally(
+      T failure) {
+    CompletableFuture<LookupResult> future = new CompletableFuture<>();
+    future.completeExceptionally(failure);
+    return future;
+  }
+
+  private CompletionStage<LookupResult> resolveRedirects(LookupResult response, Record query) {
+    CompletableFuture<LookupResult> future = new CompletableFuture<>();
+    maybeFollowRedirect(response, query, 1, future);
+    return future;
+  }
+
+  private void maybeFollowRedirect(
+      LookupResult response,
+      Record query,
+      int redirectCount,
+      CompletableFuture<LookupResult> future) {
+    try {
+      if (redirectCount > maxRedirects) {
+        throw new RedirectOverflowException(
+            String.format("Refusing to follow more than %s redirects", maxRedirects));
+      }
+
+      List<Record> records = response.getRecords();
+      if (records.isEmpty()) {
+        future.complete(response);
+      } else if (records.get(0).getType() == Type.DNAME || records.get(0).getType() == Type.CNAME) {
+        lookupWithCache(
+                buildRedirectQuery(response, query),
+                makeAliases(response.getAliases(), query.getName()))
+            .thenAccept(m -> maybeFollowRedirect(m, query, redirectCount + 1, future));
+      } else {
+        future.complete(response);
+      }
+    } catch (LookupFailedException e) {
+      future.completeExceptionally(e);
+    }
+  }
+
+  /** Return an unmodifiable list containing the contents of previous, if any, plus name. */
+  private List<Name> makeAliases(List<Name> previous, Name name) {
+    if (previous == null) {
+      return Collections.singletonList(name);
+    } else {
+      List<Name> copy = new ArrayList<>(previous);
+      copy.add(name);
+      return Collections.unmodifiableList(copy);
+    }
+  }
+
+  private Record buildRedirectQuery(LookupResult response, Record question) {
+    List<Record> answer = response.getRecords();
+    Record firstAnswer = answer.get(0);
+    if (answer.size() != 1) {
+      throw new InvalidZoneDataException("Multiple CNAME RRs not allowed, see RFC1034 3.6.2");
+    }
+
+    if (firstAnswer.getType() == Type.CNAME) {
+      return Record.newRecord(
+          ((CNAMERecord) firstAnswer).getTarget(), question.getType(), question.getDClass());
+    }
+    // if it is not a CNAME, it's a DNAME
+    try {
+      Name name = question.getName().fromDNAME((DNAMERecord) firstAnswer);
+      return Record.newRecord(name, question.getType(), question.getDClass());
+    } catch (NameTooLongException e) {
+      throw new InvalidZoneDataException(
+          "DNAME redirect would result in a name that would be too long");
+    }
+  }
+
+  /** Returns a LookupResult if this response was a non-exceptional empty result, else null. */
+  private static LookupResult buildResult(Message answer, List<Name> aliases, Record query) {
+    int rcode = answer.getRcode();
+    List<Record> answerRecords = answer.getSection(Section.ANSWER);
+    if (answerRecords.isEmpty()) {
+      switch (rcode) {
+        case Rcode.NXDOMAIN:
+          throw new NoSuchDomainException(query.getName(), query.getType());
+        case Rcode.NXRRSET:
+          throw new NoSuchRRSetException(query.getName(), query.getType());
+        case Rcode.SERVFAIL:
+          throw new ServerFailedException();
+        default:
+          throw new LookupFailedException(
+              String.format("Unknown non-success error code %s", Rcode.string(rcode)));
+      }
+    }
+    return new LookupResult(answerRecords, aliases);
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/NoSuchDomainException.java
+++ b/src/main/java/org/xbill/DNS/lookup/NoSuchDomainException.java
@@ -1,0 +1,13 @@
+package org.xbill.DNS.lookup;
+
+import org.xbill.DNS.Name;
+
+/**
+ * Thrown to indicate that no data is associated with the given name, as indicated by the NXDOMAIN
+ * response code as specified in RF2136 Section 2.2.
+ */
+public class NoSuchDomainException extends LookupFailedException {
+  public NoSuchDomainException(Name name, int type) {
+    super(name, type);
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/NoSuchRRSetException.java
+++ b/src/main/java/org/xbill/DNS/lookup/NoSuchRRSetException.java
@@ -1,0 +1,13 @@
+package org.xbill.DNS.lookup;
+
+import org.xbill.DNS.Name;
+
+/**
+ * Thrown to indicate that records of the name and type queried does not exist, corresponding to the
+ * NXRRSET return code as specified in RFC2136 Section 2.2.
+ */
+public class NoSuchRRSetException extends LookupFailedException {
+  public NoSuchRRSetException(Name name, int type) {
+    super(name, type);
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/RedirectOverflowException.java
+++ b/src/main/java/org/xbill/DNS/lookup/RedirectOverflowException.java
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+/**
+ * Thrown if the lookup results in too many CNAME and/or DNAME indirections. This would be the case
+ * for example if two CNAME records point to each other.
+ */
+public class RedirectOverflowException extends LookupFailedException {
+  public RedirectOverflowException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/xbill/DNS/lookup/ServerFailedException.java
+++ b/src/main/java/org/xbill/DNS/lookup/ServerFailedException.java
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+/**
+ * Represents a server failure, that the upstream server responding to the request returned a
+ * SERVFAIL status.
+ */
+public class ServerFailedException extends LookupFailedException {}

--- a/src/test/java/org/xbill/DNS/lookup/LookupResultTest.java
+++ b/src/test/java/org/xbill/DNS/lookup/LookupResultTest.java
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-2-Clause
+package org.xbill.DNS.lookup;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+import org.xbill.DNS.ARecord;
+import org.xbill.DNS.DClass;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+
+class LookupResultTest {
+  @Test
+  void ctor_nullRecords() {
+    assertThrows(NullPointerException.class, () -> new LookupResult(null, null));
+  }
+
+  @Test
+  void getResult() {
+    Record record =
+        new ARecord(Name.fromConstantString("a."), DClass.IN, 0, InetAddress.getLoopbackAddress());
+    LookupResult lookupResult = new LookupResult(singletonList(record), null);
+    assertEquals(singletonList(record), lookupResult.getRecords());
+  }
+
+  @Test
+  void getAliases() {
+    Name name = Name.fromConstantString("b.");
+    Record record = new ARecord(name, DClass.IN, 0, InetAddress.getLoopbackAddress());
+    LookupResult lookupResult = new LookupResult(singletonList(record), singletonList(name));
+    assertEquals(singletonList(name), lookupResult.getAliases());
+  }
+}

--- a/src/test/java/org/xbill/DNS/lookup/LookupSessionTest.java
+++ b/src/test/java/org/xbill/DNS/lookup/LookupSessionTest.java
@@ -1,0 +1,540 @@
+package org.xbill.DNS.lookup;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.xbill.DNS.DClass.IN;
+import static org.xbill.DNS.LookupTest.DUMMY_NAME;
+import static org.xbill.DNS.LookupTest.LONG_LABEL;
+import static org.xbill.DNS.LookupTest.answer;
+import static org.xbill.DNS.LookupTest.fail;
+import static org.xbill.DNS.Type.A;
+import static org.xbill.DNS.Type.CNAME;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.xbill.DNS.*;
+
+@ExtendWith(MockitoExtension.class)
+class LookupSessionTest {
+
+  @Mock Resolver mockResolver;
+
+  @AfterEach
+  void after() {
+    verifyNoMoreInteractions(mockResolver);
+  }
+
+  @Test
+  void lookupAsync_absoluteQuery() throws InterruptedException, ExecutionException {
+    wireUpMockResolver(mockResolver, query -> answer(query, name -> LOOPBACK_A));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture =
+        lookupSession.lookupAsync(Name.fromConstantString("a.b."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("a.b."))), result.getRecords());
+
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_absoluteQueryWithCacheMiss() throws InterruptedException, ExecutionException {
+    wireUpMockResolver(mockResolver, query -> answer(query, name -> LOOPBACK_A));
+    Cache mockCache = mock(Cache.class);
+
+    LookupSession lookupSession =
+        LookupSession.builder().resolver(mockResolver).cache(IN, mockCache).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("a.b."))), result.getRecords());
+
+    verify(mockResolver).sendAsync(any());
+    verify(mockCache).lookupRecords(name("a.b."), A, Credibility.NORMAL);
+
+    ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(mockCache).addMessage(messageCaptor.capture());
+    Record question = messageCaptor.getValue().getQuestion();
+    assertEquals(IN, question.getDClass());
+    assertEquals(A, question.getType());
+    assertEquals(name("a.b."), question.getName());
+
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void lookupAsync_absoluteQueryWithCacheHit() throws InterruptedException, ExecutionException {
+    Name aName = name("a.b.");
+
+    Cache mockCache = mock(Cache.class);
+    SetResponse response = mock(SetResponse.class);
+    when(response.isSuccessful()).thenReturn(true);
+    when(response.answers()).thenReturn(singletonList(new RRset(LOOPBACK_A.withName(aName))));
+    when(mockCache.lookupRecords(aName, IN, Credibility.NORMAL)).thenReturn(response);
+
+    LookupSession lookupSession =
+        LookupSession.builder().resolver(mockResolver).cache(IN, mockCache).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(aName, A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(aName)), result.getRecords());
+
+    verify(mockCache).lookupRecords(aName, A, Credibility.NORMAL);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void lookupAsync_searchPathWithCacheMissAndHit() throws InterruptedException, ExecutionException {
+
+    wireUpMockResolver(mockResolver, q -> answer(q, n -> cname("host.tld.", "another.tld.")));
+
+    Cache mockCache = mock(Cache.class);
+    // interestingly, a non-configured mock behaves the same way as a cache miss return value.
+    when(mockCache.lookupRecords(name("host.tld."), IN, Credibility.NORMAL))
+        .thenReturn(mock(SetResponse.class));
+
+    SetResponse second = mock(SetResponse.class);
+    when(second.isSuccessful()).thenReturn(true);
+    when(second.answers())
+        .thenReturn(singletonList(new RRset(LOOPBACK_A.withName(name("another.tld.")))));
+    when(mockCache.lookupRecords(name("another.tld."), IN, Credibility.NORMAL)).thenReturn(second);
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .cache(IN, mockCache)
+            .searchPath(name("tld."))
+            .build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("host"), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("another.tld."))), result.getRecords());
+
+    verify(mockCache).lookupRecords(name("host.tld."), A, Credibility.NORMAL);
+    verify(mockCache).addMessage(any());
+    verify(mockCache).lookupRecords(name("another.tld."), A, Credibility.NORMAL);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void lookupAsync_negativeCacheRecords() throws InterruptedException, ExecutionException {
+
+    Cache mockCache = mock(Cache.class);
+
+    SetResponse first = mock(SetResponse.class);
+    when(first.isNXDOMAIN()).thenReturn(true);
+    when(mockCache.lookupRecords(name("host.tld1."), IN, Credibility.NORMAL)).thenReturn(first);
+
+    SetResponse second = mock(SetResponse.class);
+    when(second.isNXRRSET()).thenReturn(true);
+    when(mockCache.lookupRecords(name("host.tld2."), IN, Credibility.NORMAL)).thenReturn(second);
+
+    SetResponse third = mock(SetResponse.class);
+    when(third.isSuccessful()).thenReturn(true);
+    when(third.answers())
+        .thenReturn(singletonList(new RRset(LOOPBACK_A.withName(name("host.tld3.")))));
+    when(mockCache.lookupRecords(name("host.tld3."), IN, Credibility.NORMAL)).thenReturn(third);
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .cache(IN, mockCache)
+            .searchPath(asList(name("tld1"), name("tld2"), name("tld3")))
+            .build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("host"), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("host.tld3."))), result.getRecords());
+
+    InOrder inOrder = inOrder(mockCache);
+    inOrder.verify(mockCache).lookupRecords(name("host.tld1."), A, Credibility.NORMAL);
+    inOrder.verify(mockCache).lookupRecords(name("host.tld2."), A, Credibility.NORMAL);
+    inOrder.verify(mockCache).lookupRecords(name("host.tld3."), A, Credibility.NORMAL);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void lookupAsync_simpleCnameRedirect() throws Exception {
+    Function<Name, Record> nameToRecord =
+        name -> name("cname.r.").equals(name) ? cname("cname.r.", "a.b.") : LOOPBACK_A;
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("cname.r."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("a.b."))), result.getRecords());
+    assertEquals(singletonList(name("cname.r.")), result.getAliases());
+    verify(mockResolver, times(2)).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_simpleDnameRedirect() throws Exception {
+    Function<Name, Record> nameToRecord =
+        n -> name("x.y.to.dname.").equals(n) ? dname("to.dname.", "to.a.") : LOOPBACK_A;
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+
+    CompletionStage<LookupResult> resultFuture =
+        lookupSession.lookupAsync(name("x.y.to.dname."), A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(singletonList(LOOPBACK_A.withName(name("x.y.to.a."))), result.getRecords());
+    verify(mockResolver, times(2)).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_redirectLoop() {
+    Function<Name, Record> nameToRecord =
+        name -> name("a.b.").equals(name) ? cname("a.", "b.") : cname("b.", "a.");
+    wireUpMockResolver(mockResolver, q -> answer(q, nameToRecord));
+
+    LookupSession lookupSession =
+        LookupSession.builder().resolver(mockResolver).maxRedirects(2).build();
+
+    CompletionStage<LookupResult> resultFuture =
+        lookupSession.lookupAsync(name("first.example.com."), A, IN);
+
+    assertThrowsCause(
+        RedirectOverflowException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver, times(3)).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_NXDOMAIN() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NXDOMAIN));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(NoSuchDomainException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_SERVFAIL() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.SERVFAIL));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(ServerFailedException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_unknownFailure() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NOTIMP));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(LookupFailedException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_NXRRSET() {
+    wireUpMockResolver(mockResolver, q -> fail(q, Rcode.NXRRSET));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(NoSuchRRSetException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_TooLongNameDNAME() {
+    wireUpMockResolver(
+        mockResolver, q -> answer(q, n -> dname("to.dname.", format("%s.to.a.", LONG_LABEL))));
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    Name toLookup = name(format("%s.%s.%s.to.dname.", LONG_LABEL, LONG_LABEL, LONG_LABEL));
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(toLookup, A, IN);
+
+    assertThrowsCause(
+        InvalidZoneDataException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  @Test
+  void lookupAsync_MultipleCNAMEs() {
+    // According to https://docstore.mik.ua/orelly/networking_2ndEd/dns/ch10_07.htm this is
+    // apparently something that BIND 4 did.
+    wireUpMockResolver(mockResolver, LookupSessionTest::multipleCNAMEs);
+
+    LookupSession lookupSession = LookupSession.builder().resolver(mockResolver).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("a.b."), A, IN);
+
+    assertThrowsCause(
+        InvalidZoneDataException.class, () -> resultFuture.toCompletableFuture().get());
+    verify(mockResolver).sendAsync(any());
+  }
+
+  private static Message multipleCNAMEs(Message query) {
+    Message answer = new Message(query.getHeader().getID());
+    Record question = query.getQuestion();
+    answer.addRecord(question, Section.QUESTION);
+    answer.addRecord(
+        new CNAMERecord(question.getName(), CNAME, IN, name("target1.")), Section.ANSWER);
+    answer.addRecord(
+        new CNAMERecord(question.getName(), CNAME, IN, name("target2.")), Section.ANSWER);
+    return answer;
+  }
+
+  @Test
+  void lookupAsync_searchAppended() throws Exception {
+    wireUpMockResolver(mockResolver, query -> answer(query, name -> LOOPBACK_A));
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .searchPath(singletonList(name("example.com")))
+            .build();
+
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("host"), A, IN);
+    LookupResult lookupResult = resultFuture.toCompletableFuture().get();
+
+    ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(mockResolver).sendAsync(messageCaptor.capture());
+
+    assertEquals(
+        Record.newRecord(Name.fromConstantString("host.example.com."), Type.A, DClass.IN, 0L),
+        messageCaptor.getValue().getSection(Section.QUESTION).get(0));
+
+    assertEquals(
+        singletonList(LOOPBACK_A.withName(name("host.example.com."))), lookupResult.getRecords());
+  }
+
+  @Test
+  void lookupAsync_searchAppendTooLongName() throws Exception {
+    wireUpMockResolver(mockResolver, query -> answer(query, name -> LOOPBACK_A));
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .searchPath(singletonList(name(format("%s.%s.%s", LONG_LABEL, LONG_LABEL, LONG_LABEL))))
+            .build();
+
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name(LONG_LABEL), A, IN);
+    LookupResult lookupResult = resultFuture.toCompletableFuture().get();
+
+    ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(mockResolver).sendAsync(messageCaptor.capture());
+
+    assertEquals(
+        Record.newRecord(name(LONG_LABEL + "."), A, IN, 0L),
+        messageCaptor.getValue().getSection(Section.QUESTION).get(0));
+
+    assertEquals(
+        singletonList(LOOPBACK_A.withName(name(LONG_LABEL + "."))), lookupResult.getRecords());
+  }
+
+  @Test
+  void lookupAsync_twoItemSearchPath() throws Exception {
+    wireUpMockResolver(
+        mockResolver,
+        query -> answer(query, name -> name.equals(name("host.a.")) ? null : LOOPBACK_A));
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .searchPath(asList(name("a"), name("b")))
+            .build();
+
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(name("host"), A, IN);
+    LookupResult lookupResult = resultFuture.toCompletableFuture().get();
+
+    ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(mockResolver, times(2)).sendAsync(messageCaptor.capture());
+
+    List<Message> allValues = messageCaptor.getAllValues();
+    assertEquals(
+        Record.newRecord(Name.fromConstantString("host.a."), Type.A, DClass.IN, 0L),
+        allValues.get(0).getSection(Section.QUESTION).get(0));
+    assertEquals(
+        Record.newRecord(Name.fromConstantString("host.b."), Type.A, DClass.IN, 0L),
+        allValues.get(1).getSection(Section.QUESTION).get(0));
+
+    assertEquals(singletonList(LOOPBACK_A.withName(name("host.b."))), lookupResult.getRecords());
+  }
+
+  @Test
+  void lookupAsync_absoluteQueryWithCacheNoCycleResults()
+      throws InterruptedException, ExecutionException, UnknownHostException {
+    Name aName = name("a.b.");
+    InetAddress anotherAddress = InetAddress.getByName("192.168.168.1");
+    ARecord anotherA = new ARecord(aName, IN, 3600, anotherAddress);
+
+    Cache mockCache = mock(Cache.class);
+    SetResponse response = mock(SetResponse.class);
+    when(response.isSuccessful()).thenReturn(true);
+    RRset rrSet = new RRset();
+    rrSet.addRR(LOOPBACK_A.withName(aName));
+    rrSet.addRR(anotherA);
+    when(response.answers()).thenReturn(singletonList(rrSet));
+    when(mockCache.lookupRecords(aName, IN, Credibility.NORMAL)).thenReturn(response);
+
+    LookupSession lookupSession =
+        LookupSession.builder().resolver(mockResolver).cache(IN, mockCache).build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(aName, A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(asList(LOOPBACK_A.withName(aName), anotherA), result.getRecords());
+
+    // should come out in the other order on the second try
+    resultFuture = lookupSession.lookupAsync(aName, A, IN);
+    result = resultFuture.toCompletableFuture().get();
+    assertEquals(asList(LOOPBACK_A.withName(aName), anotherA), result.getRecords());
+
+    verify(mockCache, times(2)).lookupRecords(aName, A, Credibility.NORMAL);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void lookupAsync_absoluteQueryWithCacheCycleResults()
+      throws InterruptedException, ExecutionException, UnknownHostException {
+    Name aName = name("a.b.");
+    InetAddress anotherAddress = InetAddress.getByName("192.168.168.1");
+    ARecord anotherA = new ARecord(aName, IN, 3600, anotherAddress);
+
+    Cache mockCache = mock(Cache.class);
+    SetResponse response = mock(SetResponse.class);
+    when(response.isSuccessful()).thenReturn(true);
+    RRset rrSet = new RRset();
+    rrSet.addRR(LOOPBACK_A.withName(aName));
+    rrSet.addRR(anotherA);
+    when(response.answers()).thenReturn(singletonList(rrSet));
+    when(mockCache.lookupRecords(aName, IN, Credibility.NORMAL)).thenReturn(response);
+
+    LookupSession lookupSession =
+        LookupSession.builder()
+            .resolver(mockResolver)
+            .cache(IN, mockCache)
+            .cycleResults(true)
+            .build();
+    CompletionStage<LookupResult> resultFuture = lookupSession.lookupAsync(aName, A, IN);
+
+    LookupResult result = resultFuture.toCompletableFuture().get();
+    assertEquals(asList(LOOPBACK_A.withName(aName), anotherA), result.getRecords());
+
+    // should come out in the other order on the second try
+    resultFuture = lookupSession.lookupAsync(aName, A, IN);
+    result = resultFuture.toCompletableFuture().get();
+    assertEquals(asList(anotherA, LOOPBACK_A.withName(aName)), result.getRecords());
+
+    verify(mockCache, times(2)).lookupRecords(aName, A, Credibility.NORMAL);
+    verifyNoMoreInteractions(mockCache);
+  }
+
+  @Test
+  void expandName_absolute() {
+    LookupSession session = LookupSession.builder().resolver(mockResolver).build();
+    Stream<Name> nameStream = session.expandName(name("a."));
+    assertEquals(singletonList(name("a.")), nameStream.collect(toList()));
+  }
+
+  @Test
+  void expandName_singleSearchPath() {
+    LookupSession session =
+        LookupSession.builder().resolver(mockResolver).searchPath(name("example.com.")).build();
+    Stream<Name> nameStream = session.expandName(name("host"));
+    assertEquals(asList(name("host.example.com."), name("host.")), nameStream.collect(toList()));
+  }
+
+  @Test
+  void expandName_notSetSearchPath() {
+    LookupSession session = LookupSession.builder().resolver(mockResolver).build();
+    Stream<Name> nameStream = session.expandName(name("host"));
+    assertEquals(singletonList(name("host.")), nameStream.collect(toList()));
+  }
+
+  @Test
+  void expandName_searchPathIsMadeAbsolute() {
+    LookupSession session =
+        LookupSession.builder().resolver(mockResolver).searchPath(name("example.com")).build();
+    Stream<Name> nameStream = session.expandName(name("host"));
+    assertEquals(asList(name("host.example.com."), name("host.")), nameStream.collect(toList()));
+  }
+
+  @Test
+  void expandName_defaultNdots() {
+    LookupSession session =
+        LookupSession.builder().resolver(mockResolver).searchPath(name("example.com")).build();
+    Stream<Name> nameStream = session.expandName(name("a.b"));
+    assertEquals(
+        asList(name("a.b."), name("a.b.example.com."), name("a.b.")), nameStream.collect(toList()));
+  }
+
+  @Test
+  void expandName_ndotsMoreThanOne() {
+    LookupSession session =
+        LookupSession.builder()
+            .searchPath(name("example.com."))
+            .resolver(mockResolver)
+            .ndots(2)
+            .build();
+    Stream<Name> nameStream = session.expandName(name("a.b"));
+    assertEquals(asList(name("a.b.example.com."), name("a.b.")), nameStream.collect(toList()));
+  }
+
+  private static final ARecord LOOPBACK_A =
+      new ARecord(DUMMY_NAME, IN, 3600, InetAddress.getLoopbackAddress());
+
+  private static CNAMERecord cname(String name, String target) {
+    return new CNAMERecord(name(name), IN, 0, name(target));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static DNAMERecord dname(String name, String target) {
+    return new DNAMERecord(name(name), IN, 0, name(target));
+  }
+
+  private static Name name(String name) {
+    return Name.fromConstantString(name);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private <T extends Throwable> void assertThrowsCause(Class<T> ex, Executable executable) {
+    Throwable outerException = assertThrows(Throwable.class, executable);
+    assertEquals(ex, outerException.getCause().getClass());
+  }
+
+  private void wireUpMockResolver(Resolver mockResolver, Function<Message, Message> handler) {
+    when(mockResolver.sendAsync(any(Message.class)))
+        .thenAnswer(
+            invocation -> {
+              Message query = invocation.getArgument(0);
+              return CompletableFuture.completedFuture(handler.apply(query));
+            });
+  }
+}


### PR DESCRIPTION
I have started experimenting with an asynchronous lookup mechanism. Please note that this is a draft and not not feature complete. I just want to give the opportunity to gather some early feedback. In particular I am curious to to hear about:

* The name `DNSSession` for the new long lived API endpoint. Session is kind of vague on purpose, to allow it to have other public methods in the future that interact with DNS servers. I want to avoid Session because of the inconvenience of having it clash with for example the Session classes in the Neo4j or Cassandra.
* What do we think about putting an exception hierarchy in a separate module? My main reason for going there is that the org.xbill.DNS module is pretty crowded, but this is a weak preference.

The idea is to implement the following:
* Add aliases to QueryResult
* caching
* search path expansion
* ndots handling
* the cycleResults feature
* a configurable minimum credibility requirement
Once this is in place, this query implementation would reach feature parity with Lookup.run() and we could replace that one with this without changing the public API (besides making it Deprecated, possibly).
