### PR TITLE
Have constructing relative Name with length() == MAXNAME fail

### DIFF
--- a/src/main/java/org/xbill/DNS/Name.java
+++ b/src/main/java/org/xbill/DNS/Name.java
@@ -271,6 +271,14 @@ public class Name implements Comparable<Name>, Serializable {
     if (origin != null && !absolute) {
       appendFromString(s, origin.name, origin.offset(0), origin.labels);
     }
+    // A relative name that is MAXNAME octets long is a strange and wonderful thing.
+    // Not technically in violation, but it can not be used for queries as it needs
+    // to be made absolute by appending at the very least the an empty label at the
+    // end, which there is no room for. To make life easier for everyone, let's only
+    // allow Names that are MAXNAME long if they are absolute.
+    if (!absolute && length() == MAXNAME) {
+      throw parseException(s, "Name too long");
+    }
   }
 
   /**

--- a/src/test/java/org/xbill/DNS/NameTest.java
+++ b/src/test/java/org/xbill/DNS/NameTest.java
@@ -34,6 +34,7 @@
 //
 package org.xbill.DNS;
 
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -286,15 +289,26 @@ class NameTest {
     }
 
     @Test
-    void ctor_max_length_rel() throws TextParseException {
-      // relative name with three 63-char labels and a 62-char label
+    void ctor_length_too_long_rel() {
+      // We want to fail to crate this as there is no way to make a Name that long absolute,
+      // which means that it can not be used for lookups or updates.
+      String label63 = IntStream.range(0, 63).mapToObj(i -> "a").collect(Collectors.joining());
+      String label62 = IntStream.range(0, 62).mapToObj(i -> "a").collect(Collectors.joining());
+      assertThrows(
+          TextParseException.class,
+          () -> new Name(format("%s.%s.%s.%s", label63, label63, label63, label62)));
+    }
+
+    @Test
+    void ctor_longest_allowed_rel() throws TextParseException {
+      // relative name with three 63-char labels and a 61-char label
       Name n =
           new Name(
-              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
       assertFalse(n.isAbsolute());
       assertFalse(n.isWild());
       assertEquals(4, n.labels());
-      assertEquals(255, n.length());
+      assertEquals(254, n.length());
     }
 
     @Test


### PR DESCRIPTION
The Name() constructor will currently fail if it's length() would
end up being longer than MAXNAME (255). However, there is an edge
case where a relative name can be exactly MAXNAME long. This is
legal but the lookup mechanism will then fail to make the name
absolute by appending an empty label to be able to use it for
lookups.