### PR TITLE
Properly close UDP channel upon error

### DIFF
--- a/src/main/java/org/xbill/DNS/NioUdpClient.java
+++ b/src/main/java/org/xbill/DNS/NioUdpClient.java
@@ -138,9 +138,14 @@ final class NioUdpClient extends Client {
     private void silentCloseChannel() {
       try {
         channel.disconnect();
-        channel.close();
       } catch (IOException e) {
         // ignore, we either already have everything we need or can't do anything
+      } finally {
+        try {
+          channel.close();
+        } catch (IOException e) {
+          // ignore
+        }
       }
     }
   }


### PR DESCRIPTION
We've been seeing an error very similar to the one in #95 - after an error, dnsjava would stop resolving anything and constantly time out. In our case it was also a truncated UDP response, which would fallback to TCP.

Through debugging I discovered that the errored-out channels stayed in the selector, constantly reading -1 and blocking any query sending from happening, making every query time out. What was happening is that `channel.disconnect()` was throwing an IOException ("network is unreachable"), so the channel was never closed and thus stuck in the selector. Changing the codepath to always call `channel.close()` resolved the issue.