### PR TITLE
Fix load balancing

### DIFF
--- a/src/main/java/org/xbill/DNS/ExtendedResolver.java
+++ b/src/main/java/org/xbill/DNS/ExtendedResolver.java
@@ -41,7 +41,7 @@ public class ExtendedResolver implements Resolver {
       resolvers = new ArrayList<>(eres.resolvers);
       endTime = System.nanoTime() + eres.timeout.toNanos();
       if (eres.loadBalance) {
-        int start = eres.lbStart.updateAndGet(i -> i++ % resolvers.size());
+        int start = eres.lbStart.updateAndGet(i -> i+1 % resolvers.size());
         if (start > 0) {
           List<ResolverEntry> shuffle = new ArrayList<>(resolvers.size());
           for (int i = 0; i < resolvers.size(); i++) {

--- a/src/main/java/org/xbill/DNS/ExtendedResolver.java
+++ b/src/main/java/org/xbill/DNS/ExtendedResolver.java
@@ -41,7 +41,7 @@ public class ExtendedResolver implements Resolver {
       resolvers = new ArrayList<>(eres.resolvers);
       endTime = System.nanoTime() + eres.timeout.toNanos();
       if (eres.loadBalance) {
-        int start = eres.lbStart.updateAndGet(i -> (i+1) % resolvers.size());
+        int start = eres.lbStart.updateAndGet(i -> (i + 1) % resolvers.size());
         if (start > 0) {
           List<ResolverEntry> shuffle = new ArrayList<>(resolvers.size());
           for (int i = 0; i < resolvers.size(); i++) {

--- a/src/main/java/org/xbill/DNS/ExtendedResolver.java
+++ b/src/main/java/org/xbill/DNS/ExtendedResolver.java
@@ -41,7 +41,7 @@ public class ExtendedResolver implements Resolver {
       resolvers = new ArrayList<>(eres.resolvers);
       endTime = System.nanoTime() + eres.timeout.toNanos();
       if (eres.loadBalance) {
-        int start = eres.lbStart.updateAndGet(i -> i+1 % resolvers.size());
+        int start = eres.lbStart.updateAndGet(i -> (i+1) % resolvers.size());
         if (start > 0) {
           List<ResolverEntry> shuffle = new ArrayList<>(resolvers.size());
           for (int i = 0; i < resolvers.size(); i++) {


### PR DESCRIPTION
`lbStart.updateAndGet(i -> i++ % resolvers.size())` is a no-op:

`i++` increments the local variable, which is lost, and the returned value is simply `i % resolvers.size()`