### PR TITLE
Fixed ttl for soa reacord to minimum of ttl and minimum field

### DIFF
--- a/src/main/java/org/xbill/DNS/Cache.java
+++ b/src/main/java/org/xbill/DNS/Cache.java
@@ -91,7 +91,7 @@ public class Cache {
       this.type = type;
       long cttl = 0;
       if (soa != null) {
-        cttl = soa.getMinimum();
+        cttl = Math.min(soa.getMinimum(), soa.getTTL());
       }
       this.credibility = cred;
       this.expire = limitExpire(cttl, maxttl);


### PR DESCRIPTION
I have been seeing an error where in case of negative answer(NXDOMAIN), ttl of cache is being set at MINIMUM field of the SOA record (see [issue#186](https://github.com/dnsjava/dnsjava/issues/186)) whereas [RFC2308](https://tools.ietf.org/html/rfc2308), Section 3 says:

> The TTL of this record is set from the minimum of the MINIMUM field of the SOA record and the TTL of the SOA itself, and indicates how long a resolver may cache the negative answer.

I have explore the code and found out that it indeed is being set for MINIMUM field, I have added a fix for it to set the cache ttl at minimum of the MINIMUM field of the SOA record and the TTL of the SOA.
