### PR TITLE
Rename echconfig to ech in SVCB/HTTPS records

### DIFF
--- a/src/main/java/org/xbill/DNS/HTTPSRecord.java
+++ b/src/main/java/org/xbill/DNS/HTTPSRecord.java
@@ -7,7 +7,8 @@ import java.util.List;
  * HTTPS Service Location and Parameter Binding Record
  *
  * @see <a
- *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01">draft-ietf-dnsop-svcb-https</a>
+ *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06">draft-ietf-dnsop-svcb-https</a>
+ * @since 3.3
  */
 public class HTTPSRecord extends SVCBBase {
   HTTPSRecord() {}

--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -115,6 +115,8 @@ public abstract class SVCBBase extends Record {
     parameters.add(IPV4HINT, "ipv4hint", ParameterIpv4Hint::new);
     parameters.add(ECH, "ech", ParameterEch::new);
     parameters.add(IPV6HINT, "ipv6hint", ParameterIpv6Hint::new);
+    /* Support obsolete echconfig name as an alias for ech */
+    parameters.addAlias(ECH, "echconfig");
   }
 
   public abstract static class ParameterBase {

--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -30,6 +30,7 @@ abstract class SVCBBase extends Record {
   public static final int IPV4HINT = 4;
   public static final int ECH = 5;
   public static final int IPV6HINT = 6;
+  @Deprecated public static final int ECHCONFIG = 5;
 
   protected SVCBBase() {
     svcParams = new TreeMap<>();
@@ -484,6 +485,17 @@ abstract class SVCBBase extends Record {
     @Override
     public String toString() {
       return Base64.getEncoder().encodeToString(data);
+    }
+  }
+
+  @Deprecated
+  public static class ParameterEchConfig extends ParameterEch {
+    public ParameterEchConfig() {
+      super();
+    }
+
+    public ParameterEchConfig(byte[] data) {
+      super(data);
     }
   }
 

--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -17,8 +17,14 @@ import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-/** Implements common functionality for SVCB and HTTPS records */
-abstract class SVCBBase extends Record {
+/**
+ * Implements common functionality for SVCB and HTTPS records
+ *
+ * @see <a
+ *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06">draft-ietf-dnsop-svcb-https</a>
+ * @since 3.3
+ */
+public abstract class SVCBBase extends Record {
   protected int svcPriority;
   protected Name targetName;
   protected final Map<Integer, ParameterBase> svcParams;
@@ -30,6 +36,7 @@ abstract class SVCBBase extends Record {
   public static final int IPV4HINT = 4;
   public static final int ECH = 5;
   public static final int IPV6HINT = 6;
+  /** @deprecated use {@link #ECH} */
   @Deprecated public static final int ECHCONFIG = 5;
 
   protected SVCBBase() {
@@ -488,6 +495,7 @@ abstract class SVCBBase extends Record {
     }
   }
 
+  /** @deprecated use {@link ParameterEch} */
   @Deprecated
   public static class ParameterEchConfig extends ParameterBase {
     private byte[] data;

--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -28,7 +28,7 @@ abstract class SVCBBase extends Record {
   public static final int NO_DEFAULT_ALPN = 2;
   public static final int PORT = 3;
   public static final int IPV4HINT = 4;
-  public static final int ECHCONFIG = 5;
+  public static final int ECH = 5;
   public static final int IPV6HINT = 6;
 
   protected SVCBBase() {
@@ -105,7 +105,7 @@ abstract class SVCBBase extends Record {
     parameters.add(NO_DEFAULT_ALPN, "no-default-alpn", ParameterNoDefaultAlpn::new);
     parameters.add(PORT, "port", ParameterPort::new);
     parameters.add(IPV4HINT, "ipv4hint", ParameterIpv4Hint::new);
-    parameters.add(ECHCONFIG, "echconfig", ParameterEchConfig::new);
+    parameters.add(ECH, "ech", ParameterEch::new);
     parameters.add(IPV6HINT, "ipv6hint", ParameterIpv6Hint::new);
   }
 
@@ -442,14 +442,14 @@ abstract class SVCBBase extends Record {
     }
   }
 
-  public static class ParameterEchConfig extends ParameterBase {
+  public static class ParameterEch extends ParameterBase {
     private byte[] data;
 
-    public ParameterEchConfig() {
+    public ParameterEch() {
       super();
     }
 
-    public ParameterEchConfig(byte[] data) {
+    public ParameterEch(byte[] data) {
       super();
       this.data = data;
     }
@@ -460,7 +460,7 @@ abstract class SVCBBase extends Record {
 
     @Override
     public int getKey() {
-      return ECHCONFIG;
+      return ECH;
     }
 
     @Override
@@ -471,7 +471,7 @@ abstract class SVCBBase extends Record {
     @Override
     public void fromString(String string) throws TextParseException {
       if (string == null || string.isEmpty()) {
-        throw new TextParseException("Non-empty base64 value must be specified for echconfig");
+        throw new TextParseException("Non-empty base64 value must be specified for ech");
       }
       data = Base64.getDecoder().decode(string);
     }

--- a/src/main/java/org/xbill/DNS/SVCBBase.java
+++ b/src/main/java/org/xbill/DNS/SVCBBase.java
@@ -489,13 +489,48 @@ abstract class SVCBBase extends Record {
   }
 
   @Deprecated
-  public static class ParameterEchConfig extends ParameterEch {
+  public static class ParameterEchConfig extends ParameterBase {
+    private byte[] data;
+
     public ParameterEchConfig() {
       super();
     }
 
     public ParameterEchConfig(byte[] data) {
-      super(data);
+      super();
+      this.data = data;
+    }
+
+    public byte[] getData() {
+      return data;
+    }
+
+    @Override
+    public int getKey() {
+      return ECHCONFIG;
+    }
+
+    @Override
+    public void fromWire(byte[] bytes) {
+      data = bytes;
+    }
+
+    @Override
+    public void fromString(String string) throws TextParseException {
+      if (string == null || string.isEmpty()) {
+        throw new TextParseException("Non-empty base64 value must be specified for echconfig");
+      }
+      data = Base64.getDecoder().decode(string);
+    }
+
+    @Override
+    public byte[] toWire() {
+      return data;
+    }
+
+    @Override
+    public String toString() {
+      return Base64.getEncoder().encodeToString(data);
     }
   }
 

--- a/src/main/java/org/xbill/DNS/SVCBRecord.java
+++ b/src/main/java/org/xbill/DNS/SVCBRecord.java
@@ -7,7 +7,8 @@ import java.util.List;
  * Service Location and Parameter Binding Record
  *
  * @see <a
- *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01">draft-ietf-dnsop-svcb-https</a>
+ *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06">draft-ietf-dnsop-svcb-https</a>
+ * @since 3.3
  */
 public class SVCBRecord extends SVCBBase {
   SVCBRecord() {}

--- a/src/main/java/org/xbill/DNS/Type.java
+++ b/src/main/java/org/xbill/DNS/Type.java
@@ -227,7 +227,7 @@ public final class Type {
    * Service Location and Parameter Binding
    *
    * @see <a
-   *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01">draft-ietf-dnsop-svcb-https</a>
+   *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06">draft-ietf-dnsop-svcb-https</a>
    */
   public static final int SVCB = 64;
 
@@ -235,7 +235,7 @@ public final class Type {
    * HTTPS Service Location and Parameter Binding
    *
    * @see <a
-   *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01">draft-ietf-dnsop-svcb-https</a>
+   *     href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06">draft-ietf-dnsop-svcb-https</a>
    */
   public static final int HTTPS = 65;
 

--- a/src/test/java/org/xbill/DNS/HTTPSRecordTest.java
+++ b/src/test/java/org/xbill/DNS/HTTPSRecordTest.java
@@ -44,6 +44,10 @@ public class HTTPSRecordTest {
     assertEquals(HTTPSRecord.ECH, ech.getKey());
     assertEquals(data, ech.getData());
 
+    HTTPSRecord.ParameterEchConfig echconfig = new HTTPSRecord.ParameterEchConfig(data);
+    assertEquals(HTTPSRecord.ECHCONFIG, echconfig.getKey());
+    assertEquals(data, echconfig.getData());
+
     List<Inet6Address> ipv6List =
         Collections.singletonList((Inet6Address) InetAddress.getByName("2001:db8::1"));
     HTTPSRecord.ParameterIpv6Hint ipv6hint = new HTTPSRecord.ParameterIpv6Hint(ipv6List);

--- a/src/test/java/org/xbill/DNS/HTTPSRecordTest.java
+++ b/src/test/java/org/xbill/DNS/HTTPSRecordTest.java
@@ -40,9 +40,9 @@ public class HTTPSRecordTest {
     assertEquals(ipv4List, ipv4hint.getAddresses());
 
     byte[] data = {'a', 'b', 'c'};
-    HTTPSRecord.ParameterEchConfig echconfig = new HTTPSRecord.ParameterEchConfig(data);
-    assertEquals(HTTPSRecord.ECHCONFIG, echconfig.getKey());
-    assertEquals(data, echconfig.getData());
+    SVCBBase.ParameterEch ech = new SVCBBase.ParameterEch(data);
+    assertEquals(HTTPSRecord.ECH, ech.getKey());
+    assertEquals(data, ech.getData());
 
     List<Inet6Address> ipv6List =
         Collections.singletonList((Inet6Address) InetAddress.getByName("2001:db8::1"));
@@ -107,8 +107,8 @@ public class HTTPSRecordTest {
   }
 
   @Test
-  void serviceModeEchConfigMulti() throws IOException {
-    String str = "1 h3pool. alpn=h2,h3 echconfig=1234";
+  void serviceModeEchMulti() throws IOException {
+    String str = "1 h3pool. alpn=h2,h3 ech=1234";
     assertEquals(str, SVCBRecordTest.stringToWireToString(str));
   }
 

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -41,9 +41,9 @@ public class SVCBRecordTest {
     assertEquals(ipv4List, ipv4hint.getAddresses());
 
     byte[] data = {'a', 'b', 'c'};
-    SVCBRecord.ParameterEchConfig echconfig = new SVCBRecord.ParameterEchConfig(data);
-    assertEquals(SVCBRecord.ECHCONFIG, echconfig.getKey());
-    assertEquals(data, echconfig.getData());
+    SVCBBase.ParameterEch ech = new SVCBBase.ParameterEch(data);
+    assertEquals(SVCBRecord.ECH, ech.getKey());
+    assertEquals(data, ech.getData());
 
     List<Inet6Address> ipv6List =
         Collections.singletonList((Inet6Address) InetAddress.getByName("2001:db8::1"));
@@ -198,27 +198,27 @@ public class SVCBRecordTest {
   }
 
   @Test
-  void serviceModeEchConfig() throws IOException {
-    String str = "1 h3pool. echconfig=1234";
+  void serviceModeEch() throws IOException {
+    String str = "1 h3pool. ech=1234";
     assertEquals(str, stringToWireToString(str));
   }
 
   @Test
-  void serviceModeEchConfigMulti() throws IOException {
-    String str = "1 h3pool. alpn=h2,h3 echconfig=1234";
+  void serviceModeEchMulti() throws IOException {
+    String str = "1 h3pool. alpn=h2,h3 ech=1234";
     assertEquals(str, stringToWireToString(str));
   }
 
   @Test
-  void serviceModeEchConfigOutOfOrder() throws IOException {
-    String str = "1 h3pool. echconfig=1234 alpn=h2,h3";
-    assertEquals("1 h3pool. alpn=h2,h3 echconfig=1234", stringToWireToString(str));
+  void serviceModeEchOutOfOrder() throws IOException {
+    String str = "1 h3pool. ech=1234 alpn=h2,h3";
+    assertEquals("1 h3pool. alpn=h2,h3 ech=1234", stringToWireToString(str));
   }
 
   @Test
-  void serviceModeEchConfigQuoted() throws IOException {
-    String str = "1 h3pool. alpn=h2,h3 echconfig=\"1234\"";
-    assertEquals("1 h3pool. alpn=h2,h3 echconfig=1234", stringToWireToString(str));
+  void serviceModeEchQuoted() throws IOException {
+    String str = "1 h3pool. alpn=h2,h3 ech=\"1234\"";
+    assertEquals("1 h3pool. alpn=h2,h3 ech=1234", stringToWireToString(str));
   }
 
   @Test
@@ -377,8 +377,8 @@ public class SVCBRecordTest {
   }
 
   @Test
-  void zeroLengthEchConfig() {
-    String str = "1 . echconfig";
+  void zeroLengthEch() {
+    String str = "1 . ech";
     assertThrows(TextParseException.class, () -> stringToWire(str));
   }
 

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -226,6 +226,12 @@ public class SVCBRecordTest {
   }
 
   @Test
+  void serviceModeObsoleteEchConfigName() throws IOException {
+    String str = "1 . echconfig=1234";
+    assertEquals("1 . ech=1234", stringToWireToString(str));
+  }
+
+  @Test
   void serviceModeIpv4Hint() throws IOException {
     String str = "3 . ipv4hint=4.5.6.7";
     assertEquals(str, stringToWireToString(str));
@@ -497,12 +503,6 @@ public class SVCBRecordTest {
   @Test
   void invalidIpv6Hint() {
     String str = "1 . ipv6hint=1.2.3.4";
-    assertThrows(TextParseException.class, () -> stringToWire(str));
-  }
-
-  @Test
-  void obsoleteEchConfigName() {
-    String str = "1 . echconfig=1234";
     assertThrows(TextParseException.class, () -> stringToWire(str));
   }
 

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -45,6 +45,10 @@ public class SVCBRecordTest {
     assertEquals(SVCBRecord.ECH, ech.getKey());
     assertEquals(data, ech.getData());
 
+    SVCBRecord.ParameterEchConfig echconfig = new SVCBRecord.ParameterEchConfig(data);
+    assertEquals(SVCBRecord.ECHCONFIG, echconfig.getKey());
+    assertEquals(data, echconfig.getData());
+
     List<Inet6Address> ipv6List =
         Collections.singletonList((Inet6Address) InetAddress.getByName("2001:db8::1"));
     SVCBRecord.ParameterIpv6Hint ipv6hint = new SVCBRecord.ParameterIpv6Hint(ipv6List);

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -497,6 +497,12 @@ public class SVCBRecordTest {
   }
 
   @Test
+  void obsoleteEchConfigName() {
+    String str = "1 . echconfig=1234";
+    assertThrows(TextParseException.class, () -> stringToWire(str));
+  }
+
+  @Test
   void negativeSvcPriority() {
     String str = "-1 . port=80";
     assertThrows(TextParseException.class, () -> stringToWire(str));


### PR DESCRIPTION
In the latest SVCB RFC draft (https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06), the parameter "echconfig" has been renamed to "ech".  This Pull Request implements that change for dnsjava, and renames the classes and variables appropriately.