### PR TITLE
Fix issue with Name compareTo and the handling of octal digit byte values

### DIFF
--- a/src/main/java/org/xbill/DNS/Name.java
+++ b/src/main/java/org/xbill/DNS/Name.java
@@ -839,7 +839,9 @@ public class Name implements Comparable<Name>, Serializable {
       int length = name[start];
       int alength = arg.name[astart];
       for (int j = 0; j < length && j < alength; j++) {
-        int n = lowercase[name[j + start + 1] & 0xFF] - lowercase[arg.name[j + astart + 1] & 0xFF];
+        int n =
+            (lowercase[name[j + start + 1] & 0xFF] & 0xFF)
+                - (lowercase[arg.name[j + astart + 1] & 0xFF] & 0xFF);
         if (n != 0) {
           return n;
         }

--- a/src/test/java/org/xbill/DNS/NameTest.java
+++ b/src/test/java/org/xbill/DNS/NameTest.java
@@ -1502,6 +1502,24 @@ class NameTest {
       assertTrue(n1.compareTo(n2) < 0);
       assertTrue(n2.compareTo(n1) > 0);
     }
+
+    @Test
+    void octal_digits_low() throws TextParseException {
+      Name n1 = new Name("\004.b.a.");
+      Name n2 = new Name("c.b.a.");
+
+      assertTrue(n1.compareTo(n2) < 0);
+      assertTrue(n2.compareTo(n1) > 0);
+    }
+
+    @Test
+    void octal_digits_high() throws TextParseException {
+      Name n1 = new Name("c.b.a.");
+      Name n2 = new Name("\237.b.a.");
+
+      assertTrue(n1.compareTo(n2) < 0);
+      assertTrue(n2.compareTo(n1) > 0);
+    }
   }
 
   @Test

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -507,12 +507,6 @@ public class SVCBRecordTest {
   }
 
   @Test
-  void obsoleteEchConfigName() {
-    String str = "1 . echconfig=1234";
-    assertThrows(TextParseException.class, () -> stringToWire(str));
-  }
-
-  @Test
   void negativeSvcPriority() {
     String str = "-1 . port=80";
     assertThrows(TextParseException.class, () -> stringToWire(str));

--- a/src/test/java/org/xbill/DNS/SVCBRecordTest.java
+++ b/src/test/java/org/xbill/DNS/SVCBRecordTest.java
@@ -507,6 +507,12 @@ public class SVCBRecordTest {
   }
 
   @Test
+  void obsoleteEchConfigName() {
+    String str = "1 . echconfig=1234";
+    assertThrows(TextParseException.class, () -> stringToWire(str));
+  }
+
+  @Test
   void negativeSvcPriority() {
     String str = "-1 . port=80";
     assertThrows(TextParseException.class, () -> stringToWire(str));


### PR DESCRIPTION
The Name.compareTo() function has a bug with its handling of octal digits byte values that are greater than 128.  The lookup in the lowercase array was returning a signed byte that was implicitly cast to a signed int, resulting in a negative number.  This would cause such values to be incorrectly treated as less than those in the 0-127 range.

This PR fixes the issue and adds test to verify the behavior.  The fix is simply to perform another "& 0xFF" on the value that comes back from the lookup in the lowercase array.  The octal_digits_high() test would previously have failed without this fix.