### PR TITLE
removed synchronization in Header::getID

### DIFF
--- a/src/main/java/org/xbill/DNS/Header.java
+++ b/src/main/java/org/xbill/DNS/Header.java
@@ -31,15 +31,14 @@ public class Header implements Cloneable {
    * @param id The message id
    */
   public Header(int id) {
-    this();
-    setID(id);
+    counts = new int[4];
+    flags = 0;
+    this.id = id;
   }
 
   /** Create a new empty header with a random message id */
   public Header() {
-    counts = new int[4];
-    flags = 0;
-    id = -1;
+    this(random.nextInt(0xffff));
   }
 
   /** Parses a Header from a stream containing DNS wire format. */
@@ -138,12 +137,7 @@ public class Header implements Cloneable {
 
   /** Retrieves the message ID */
   public int getID() {
-    synchronized (random) {
-      if (id < 0) {
-        id = random.nextInt(0xffff);
-      }
-      return id;
-    }
+    return id;
   }
 
   /** Sets the message ID */


### PR DESCRIPTION
Header::getID synchronized on a static field causing unnecessary locking
especially when the ID field didn't need to be generated. As per the
discussion in #215, this was due to a desire to have the ID generation
be lazy, which is no longer needed.

This commit changes the ID generation behavior so the ID is either
explicitly supplied to the constructor, or generated by the constructor
using the same SecureRandom instance. This makes the getID method a
simple getter with no need for synchronization