### PR TITLE
Change semantics of DNSInput.saveActive()

### DIFF
--- a/src/main/java/org/xbill/DNS/DNSInput.java
+++ b/src/main/java/org/xbill/DNS/DNSInput.java
@@ -79,7 +79,7 @@ public class DNSInput {
 
   /** Returns the position of the end of the current active region. */
   public int saveActive() {
-    return limit - offset;
+    return byteBuffer.limit() - offset;
   }
 
   /**

--- a/src/test/java/org/xbill/DNS/OPTRecordTest.java
+++ b/src/test/java/org/xbill/DNS/OPTRecordTest.java
@@ -6,10 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.xbill.DNS.DNSSEC.Algorithm;
 import org.xbill.DNS.DNSSEC.Digest;
 import org.xbill.DNS.EDNSOption.Code;
+import org.xbill.DNS.utils.base16;
 
 class OPTRecordTest {
 
@@ -80,6 +83,24 @@ class OPTRecordTest {
             TextParseException.class,
             () -> new OPTRecord().rdataFromString(new Tokenizer(" "), null));
     assertTrue(thrown.getMessage().contains("no text format defined for OPT"));
+  }
+
+  @Test
+  void rdataFromWire() throws IOException {
+    byte[] buf = base16.fromString("000029100000000000000C000A00084531D089BA80C6EB");
+    OPTRecord record = (OPTRecord) OPTRecord.fromWire(new DNSInput(buf), Section.ADDITIONAL);
+    assertEquals(
+        Arrays.asList(new CookieOption(base16.fromString("4531D089BA80C6EB"))),
+        record.getOptions());
+  }
+
+  @Test
+  void rdataFromWire_nullPadded() throws IOException {
+    byte[] buf = base16.fromString("000029100000000000000C000A00084531D089BA80C6EB00");
+    OPTRecord record = (OPTRecord) OPTRecord.fromWire(new DNSInput(buf), Section.ADDITIONAL);
+    assertEquals(
+        Arrays.asList(new CookieOption(base16.fromString("4531D089BA80C6EB"))),
+        record.getOptions());
   }
 
   private void assertNotEqual(final OPTRecord optRecordOne, final OPTRecord optRecordTwo) {


### PR DESCRIPTION
Previously, DNSInput.saveActive() would return the active range without
taking prior calls to setActive() into account.

Add a test case that illustrates the failure that the user experienced.

Please see https://github.com/dnsjava/dnsjava/issues/225 for further
details.