### PR TITLE
Ensure that empty TXT records always renders as ""

### DIFF
--- a/src/main/java/org/xbill/DNS/TXTBase.java
+++ b/src/main/java/org/xbill/DNS/TXTBase.java
@@ -73,6 +73,10 @@ abstract class TXTBase extends Record {
   /** converts to a String */
   @Override
   protected String rrToString() {
+    if (strings.isEmpty()) {
+      // always return at least an empty quoted String
+      return "\"\"";
+    }
     StringBuilder sb = new StringBuilder();
     Iterator<byte[]> it = strings.iterator();
     while (it.hasNext()) {

--- a/src/test/java/org/xbill/DNS/RecordTest.java
+++ b/src/test/java/org/xbill/DNS/RecordTest.java
@@ -912,4 +912,12 @@ class RecordTest {
       }
     }
   }
+
+  // https://github.com/dnsjava/dnsjava/issues/254
+  @Test
+  void testEmptyTXTSerialization() throws IOException {
+    Name recordName = Name.fromString("name.name.");
+    Record r = Record.fromString(recordName, Type.TXT, DClass.IN, 0, "", recordName);
+    assertEquals("name.name.\t\t0\tIN\tTXT\t\"\"", r.toString());
+  }
 }


### PR DESCRIPTION
Instantiating an empty TXT record using Record.fromString() would
previously render as a TXT without the empty string.

Closes #254