### PR TITLE
Fix Name constructor failing with max length relative name and root origin

### DIFF
--- a/src/main/java/org/xbill/DNS/Name.java
+++ b/src/main/java/org/xbill/DNS/Name.java
@@ -271,6 +271,7 @@ public class Name implements Comparable<Name>, Serializable {
       appendFromString(s, label, pos);
     }
     if (origin != null && !absolute) {
+      absolute = origin.isAbsolute();
       appendFromString(s, origin.name, origin.labels);
     }
     // A relative name that is MAXNAME octets long is a strange and wonderful thing.

--- a/src/test/java/org/xbill/DNS/NameTest.java
+++ b/src/test/java/org/xbill/DNS/NameTest.java
@@ -351,6 +351,55 @@ class NameTest {
     }
 
     @Test
+    void ctor_max_length_rel_with_root_origin() throws TextParseException {
+      // relative name with three 63-char labels and a 61-char label with Name.root as origin
+      Name n =
+          new Name(
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              Name.root);
+      assertTrue(n.isAbsolute());
+      assertFalse(n.isWild());
+      assertEquals(5, n.labels());
+      assertEquals(255, n.length());
+    }
+
+    @Test
+    void ctor_max_length_rel_with_abs_origin() throws TextParseException {
+      // relative name with three 63-char labels and a 52-char label with 9-char absolute name as
+      // origin
+      Name n =
+          new Name(
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.dddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              Name.fromString("absolute."));
+      assertTrue(n.isAbsolute());
+      assertFalse(n.isWild());
+      assertEquals(6, n.labels());
+      assertEquals(255, n.length());
+    }
+
+    @Test
+    void ctor_too_long_rel_with_rel_origin() throws TextParseException {
+      // relative name with three 63-char labels and a 53-char label with an 8-char relative origin
+      assertThrows(
+          TextParseException.class,
+          () ->
+              new Name(
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.ddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                  new Name("relative")));
+    }
+
+    @Test
+    void ctor_too_long_rel_with_abs_origin() {
+      // relative name with three 63-char labels and a 53-char label with a 9-char absolute origin
+      assertThrows(
+          TextParseException.class,
+          () ->
+              new Name(
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.ddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                  new Name("absolute.")));
+    }
+
+    @Test
     void ctor_escaped() throws TextParseException {
       Name n = new Name("ab\\123cd");
       assertFalse(n.isAbsolute());


### PR DESCRIPTION
The Name constructor failed when passing a max-length (253 chars) relative name and Name.root as origin, while this name is technically allowed.

The failure was caused by the Name constructor having the local "absolute" variable wrongly set to false in this case. This change fixes this by updating this flag when the origin is present.

Previous to this fix the workaround was to pass a null origin and manually append the final dot (root) to the string: in this case the constructor would work (as demonstrated by the "ctor_max_length_abs" test.

With this change I've also added a few tests for these edge-cases.