### PR TITLE
BUG: Use executor in the `sendAsync(query, resolveListener)`

### DIFF
--- a/src/main/java/org/xbill/DNS/Resolver.java
+++ b/src/main/java/org/xbill/DNS/Resolver.java
@@ -253,7 +253,7 @@ public interface Resolver {
 
           listener.receiveMessage(id, result);
           return null;
-        });
+        }, executor);
     return id;
   }
 }

--- a/src/main/java/org/xbill/DNS/Resolver.java
+++ b/src/main/java/org/xbill/DNS/Resolver.java
@@ -212,7 +212,7 @@ public interface Resolver {
           public void handleException(Object id, Exception e) {
             f.completeExceptionally(e);
           }
-        });
+        }, executor);
     return f;
   }
 
@@ -231,8 +231,13 @@ public interface Resolver {
    */
   @Deprecated
   default Object sendAsync(Message query, ResolverListener listener) {
+    return sendAsync(query, listener, ForkJoinPool.commonPool());
+  }
+
+  @Deprecated
+  default Object sendAsync(Message query, ResolverListener listener, Executor executor) {
     final Object id = new Object();
-    CompletionStage<Message> f = sendAsync(query);
+    CompletionStage<Message> f = sendAsync(query, executor);
     f.handleAsync(
         (result, throwable) -> {
           if (throwable != null) {


### PR DESCRIPTION
It starts with the `sendAsync(Message query, Executor executor)`. This method does not use `executor` at all.

Instead, it calls `sendAsync(Message, ResolverListener)`, which calls `sendAsync(query)` that is executed on common `ForkJoinPool`.

It seems we are missing a default `sendAsync(Message query, ResolverListener listener, Executor executor)`.

Wdyt?

EDIT: I forgot to mention that the existing code may lead to endless recursive calls; this is how I figured out the issue.

⚠️ Important: The inter-callilng of `Async` is _very_ messy. I am seeing the recursion loop between functions. Before my change, the loop consists of 3 functions. Now its 2, but still exist. It has to be fixed :( 