### PR TITLE
Allow end-user to construct clients for SimpleResolver

### DIFF
--- a/src/main/java/org/xbill/DNS/DefaultResolverClient.java
+++ b/src/main/java/org/xbill/DNS/DefaultResolverClient.java
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2005 Brian Wellington (bwelling@xbill.org)
+
+package org.xbill.DNS;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation of the ResolverClient that serves as a bridge to the internal static instances
+ * of the Nio clients.
+ *
+ * @see NioUdpClient
+ * @see NioTcpClient
+ * @since 3.6
+ */
+public class DefaultResolverClient implements TcpResolverClient, UdpResolverClient {
+
+  @Override
+  public CompletableFuture<byte[]> sendAndReceiveTcp(
+      InetSocketAddress local,
+      InetSocketAddress remote,
+      Message query,
+      byte[] data,
+      Duration timeout) {
+    return NioTcpClient.sendrecv(local, remote, query, data, timeout);
+  }
+
+  @Override
+  public CompletableFuture<byte[]> sendAndReceiveUdp(
+      InetSocketAddress local,
+      InetSocketAddress remote,
+      Message query,
+      byte[] data,
+      int max,
+      Duration timeout) {
+    return NioUdpClient.sendrecv(local, remote, query, data, max, timeout);
+  }
+}

--- a/src/main/java/org/xbill/DNS/DefaultResolverClientFactory.java
+++ b/src/main/java/org/xbill/DNS/DefaultResolverClientFactory.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2005 Brian Wellington (bwelling@xbill.org)
+
+package org.xbill.DNS;
+
+/**
+ * Serves as a default implementation that is used by the SimpleResolver unless otherwise configured
+ * by the end-user. This preserves the default behavior (to use the built-in NIO clients) while
+ * allowing flexibility at the point of use.
+ *
+ * @since 3.6
+ */
+public class DefaultResolverClientFactory implements ResolverClientFactory {
+
+  /**
+   * Shared instance because it only serves as a bridge to the static NIO classes and does not need
+   * to be different per class.
+   */
+  private static final DefaultResolverClient RESOLVER_CLIENT = new DefaultResolverClient();
+
+  @Override
+  public TcpResolverClient createOrGetTcpClient() {
+    return RESOLVER_CLIENT;
+  }
+
+  @Override
+  public UdpResolverClient createOrGetUdpClient() {
+    return RESOLVER_CLIENT;
+  }
+}

--- a/src/main/java/org/xbill/DNS/ResolverClientFactory.java
+++ b/src/main/java/org/xbill/DNS/ResolverClientFactory.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2005 Brian Wellington (bwelling@xbill.org)
+
+package org.xbill.DNS;
+
+/**
+ * Interface for creating the TCP/UDP factories necessary for the simple resolver.
+ *
+ * @since 3.6
+ */
+public interface ResolverClientFactory {
+
+  /**
+   * Create or return a cached/reused instance of the TCP resolver that should be used to send UDP
+   * over the wire to the remote target. <br>
+   * It is the responsibility of this method to manage pooling or connection reuse. This method is
+   * called right before the connection is made every time the simple resolver is called. The
+   * implementer of this method should be aware and choose how to pool or reuse connections.
+   *
+   * @since 3.6
+   * @return an instance of the tcp resolver client
+   */
+  TcpResolverClient createOrGetTcpClient();
+
+  /**
+   * Create or return a cached/reused instance of the UDP resolver that should be used to send UDP
+   * over the wire to the remote target.
+   *
+   * @since 3.6
+   * @return an instance of the udp resolver client
+   */
+  UdpResolverClient createOrGetUdpClient();
+}

--- a/src/main/java/org/xbill/DNS/TcpResolverClient.java
+++ b/src/main/java/org/xbill/DNS/TcpResolverClient.java
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2005 Brian Wellington (bwelling@xbill.org)
+
+package org.xbill.DNS;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/** @since 3.6 */
+public interface TcpResolverClient {
+
+  /**
+   * Serves as an interface from a resolver to the underlying mechanism for sending bytes over the
+   * wire as a TCP message.
+   *
+   * @since 3.6
+   * @param local address from which the connection is coming
+   * @param remote address that the connection should send the data to
+   * @param query DNS message representation of the outbound query
+   * @param data raw byte representation of the outbound query
+   * @param timeout in milliseconds before the connection will time out and be closed
+   * @return a completable future that will be completed with the byte value of the response
+   */
+  CompletableFuture<byte[]> sendAndReceiveTcp(
+      InetSocketAddress local,
+      InetSocketAddress remote,
+      Message query,
+      byte[] data,
+      Duration timeout);
+}

--- a/src/main/java/org/xbill/DNS/UdpResolverClient.java
+++ b/src/main/java/org/xbill/DNS/UdpResolverClient.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2005 Brian Wellington (bwelling@xbill.org)
+
+package org.xbill.DNS;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/** @since 3.6 */
+public interface UdpResolverClient {
+
+  /**
+   * Serves as an interface from a resolver to the underlying mechanism for sending bytes over the
+   * wire as a UDP message.
+   *
+   * @since 3.6
+   * @param local address from which the connection is coming
+   * @param remote address that the connection should send the data to
+   * @param query DNS message representation of the outbound query
+   * @param data raw byte representation of the outbound query
+   * @param max size of the response buffer
+   * @param timeout in milliseconds before the connection will time out and be closed
+   * @return a completable future that will be completed with the byte value of the response
+   */
+  CompletableFuture<byte[]> sendAndReceiveUdp(
+      InetSocketAddress local,
+      InetSocketAddress remote,
+      Message query,
+      byte[] data,
+      int max,
+      Duration timeout);
+}


### PR DESCRIPTION
- added ResolverClientFactory to allow creation of clients for the simple resolver
- added a default implementation (DefaultResolverClientFactory) that returns a flyweight implementation
- added a flyweight client implementation that is simply a pass-through to the existing static methods
- added factory to SimpleResolver class
  - used simple resolver during send/recv to construct correct client and send message
  - client is aware of if it is tcp or udp at construction time

This is very much a WIP pointed at issue #253 