### PR TITLE
Remove unreachable code

### DIFF
--- a/src/main/java/org/xbill/DNS/dnssec/DnsSecVerifier.java
+++ b/src/main/java/org/xbill/DNS/dnssec/DnsSecVerifier.java
@@ -82,13 +82,6 @@ final class DnsSecVerifier {
     }
 
     List<DNSKEYRecord> keys = this.findKey(keyRrset, sigrec);
-    if (keys.isEmpty()) {
-      log.trace("Could not find appropriate key");
-      return new JustifiedSecStatus(
-          SecurityStatus.BOGUS,
-          ExtendedErrorCodeOption.DNSKEY_MISSING,
-          R.get("dnskey.no_key", sigrec.getSigner()));
-    }
 
     for (DNSKEYRecord key : keys) {
       try {
@@ -116,7 +109,8 @@ final class DnsSecVerifier {
       }
     }
 
-    return new JustifiedSecStatus(SecurityStatus.UNCHECKED, -1, null);
+    log.trace("Could not find appropriate key");
+    return new JustifiedSecStatus(SecurityStatus.BOGUS, ExtendedErrorCodeOption.DNSKEY_MISSING, R.get("dnskey.no_key", sigrec.getSigner()));
   }
 
   /**

--- a/src/main/java/org/xbill/DNS/dnssec/ValidatingResolver.java
+++ b/src/main/java/org/xbill/DNS/dnssec/ValidatingResolver.java
@@ -1003,7 +1003,7 @@ public final class ValidatingResolver implements Resolver {
 
       case NODATA:
       case NAMEERROR:
-        return this.dsReponseToKeForNodata(response, request, keyRrset);
+        return this.dsResponseToKeForNodata(response, request, keyRrset);
 
       default:
         // We've encountered an unhandled classification for this
@@ -1025,7 +1025,7 @@ public final class ValidatingResolver implements Resolver {
    *     an end to secure space, good if the DS validated. It returns null if the DS response
    *     indicated that the request wasn't a delegation point.
    */
-  private KeyEntry dsReponseToKeForNodata(SMessage response, Message request, SRRset keyRrset) {
+  private KeyEntry dsResponseToKeForNodata(SMessage response, Message request, SRRset keyRrset) {
     Name qname = request.getQuestion().getName();
     int qclass = request.getQuestion().getDClass();
     KeyEntry bogusKE = KeyEntry.newBadKeyEntry(qname, qclass, DEFAULT_TA_BAD_KEY_TTL);


### PR DESCRIPTION
Remove unreachable code to keep it simple as this is better for security code. Additionally, one simple typo is corrected for a private method.