### PR TITLE
support custom hosts file size

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -104,7 +104,7 @@ Do NOT use it.
 |false
 
 .2+|dnsjava.hostsfile.max_size
-3+|Set the size of the hosts file to be loaded at a time，in bytes.
+3+|Set the size of the hosts file to be loaded at a time,in bytes.
 |Integer
 |16384
 |1000000

--- a/README.adoc
+++ b/README.adoc
@@ -103,6 +103,12 @@ Do NOT use it.
 |true
 |false
 
+.2+|dnsjava.hostsfile.max_size
+3+|Set the size of the hosts file to be loaded at a time，in bytes.
+|Integer
+|16384
+|1000000
+
 .2+|dnsjava.nio.selector_timeout
 3+|Set selector timeout in milliseconds. Default/Max 1000, Min 1.
 |Integer

--- a/README.adoc
+++ b/README.adoc
@@ -103,8 +103,8 @@ Do NOT use it.
 |true
 |false
 
-.2+|dnsjava.hostsfile.max_size
-3+|Set the size of the hosts file to be loaded at a time,in bytes.
+.2+|dnsjava.hostsfile.max_size_bytes
+3+|Set the size of the hosts file to be loaded at a time, in bytes.
 |Integer
 |16384
 |1000000

--- a/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
+++ b/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
@@ -29,7 +29,8 @@ import org.xbill.DNS.Type;
  */
 @Slf4j
 public final class HostsFileParser {
-  private static final int MAX_FULL_CACHE_FILE_SIZE_BYTES = 16384;
+  private static final int MAX_FULL_CACHE_FILE_SIZE_BYTES = Integer.parseInt(
+    System.getProperty("dnsjava.hostsfile.max_size", "16384"));
 
   private final Map<String, InetAddress> hostsCache = new HashMap<>();
   private final Path path;

--- a/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
+++ b/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
@@ -29,7 +29,7 @@ import org.xbill.DNS.Type;
  */
 @Slf4j
 public final class HostsFileParser {
-  private static final int MAX_FULL_CACHE_FILE_SIZE_BYTES = Integer.parseInt(
+  private final int MAX_FULL_CACHE_FILE_SIZE_BYTES = Integer.parseInt(
     System.getProperty("dnsjava.hostsfile.max_size", "16384"));
 
   private final Map<String, InetAddress> hostsCache = new HashMap<>();

--- a/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
+++ b/src/main/java/org/xbill/DNS/hosts/HostsFileParser.java
@@ -30,7 +30,7 @@ import org.xbill.DNS.Type;
 @Slf4j
 public final class HostsFileParser {
   private final int MAX_FULL_CACHE_FILE_SIZE_BYTES = Integer.parseInt(
-    System.getProperty("dnsjava.hostsfile.max_size", "16384"));
+    System.getProperty("dnsjava.hostsfile.max_size_bytes", "16384"));
 
   private final Map<String, InetAddress> hostsCache = new HashMap<>();
   private final Path path;

--- a/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
+++ b/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
@@ -172,6 +172,17 @@ class HostsFileParserTest {
   }
 
   @Test
+  void testBigFileCompletelyCachedA() throws IOException {
+    System.setProperty("dnsjava.hostsfile.max_size", 1024 * 1024 * 1024 + "");
+    HostsFileParser hostsFileParser = generateLargeHostsFile("testBigFileCompletelyCachedA");
+    hostsFileParser
+      .getAddressForHost(Name.fromConstantString("localhost-10."), Type.A)
+      .orElseThrow(() -> new IllegalStateException("Host entry not found"));
+    assertEquals(1280, hostsFileParser.cacheSize());
+    System.clearProperty("dnsjava.hostsfile.max_size");
+  }
+
+  @Test
   void testBigFileIsNotCompletelyCachedAAAA() throws IOException {
     HostsFileParser hostsFileParser =
         generateLargeHostsFile("testBigFileIsNotCompletelyCachedAAAA");

--- a/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
+++ b/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
@@ -173,9 +173,9 @@ class HostsFileParserTest {
 
   @Test
   void testBigFileCompletelyCachedA() throws IOException {
-    System.setProperty("dnsjava.hostsfile.max_size_bytes", 1024 * 1024 * 1024 + "");
-    HostsFileParser hostsFileParser = generateLargeHostsFile("testBigFileCompletelyCachedA");
     try {
+      System.setProperty("dnsjava.hostsfile.max_size_bytes", 1024 * 1024 * 1024 + "");
+      HostsFileParser hostsFileParser = generateLargeHostsFile("testBigFileCompletelyCachedA");
       hostsFileParser.getAddressForHost(Name.fromConstantString("localhost-10."), Type.A)
         .orElseThrow(() -> new IllegalStateException("Host entry not found"));
       assertEquals(1280, hostsFileParser.cacheSize());

--- a/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
+++ b/src/test/java/org/xbill/DNS/hosts/HostsFileParserTest.java
@@ -173,13 +173,15 @@ class HostsFileParserTest {
 
   @Test
   void testBigFileCompletelyCachedA() throws IOException {
-    System.setProperty("dnsjava.hostsfile.max_size", 1024 * 1024 * 1024 + "");
+    System.setProperty("dnsjava.hostsfile.max_size_bytes", 1024 * 1024 * 1024 + "");
     HostsFileParser hostsFileParser = generateLargeHostsFile("testBigFileCompletelyCachedA");
-    hostsFileParser
-      .getAddressForHost(Name.fromConstantString("localhost-10."), Type.A)
-      .orElseThrow(() -> new IllegalStateException("Host entry not found"));
-    assertEquals(1280, hostsFileParser.cacheSize());
-    System.clearProperty("dnsjava.hostsfile.max_size");
+    try {
+      hostsFileParser.getAddressForHost(Name.fromConstantString("localhost-10."), Type.A)
+        .orElseThrow(() -> new IllegalStateException("Host entry not found"));
+      assertEquals(1280, hostsFileParser.cacheSize());
+    } finally {
+      System.clearProperty("dnsjava.hostsfile.max_size_bytes");
+    }
   }
 
   @Test


### PR DESCRIPTION
Sometimes our/etc/hosts file is very large, and the machine's memory is large enough to load it into memory. At this point, we can customize this parameter.

