### PR TITLE
Fixed confusing parameter name in CNAMERecord

### DIFF
--- a/src/main/java/org/xbill/DNS/CNAMERecord.java
+++ b/src/main/java/org/xbill/DNS/CNAMERecord.java
@@ -16,10 +16,10 @@ public class CNAMERecord extends SingleCompressedNameBase {
   /**
    * Creates a new CNAMERecord with the given data
    *
-   * @param alias The name to which the CNAME alias points
+   * @param target The name to which the CNAME alias points
    */
-  public CNAMERecord(Name name, int dclass, long ttl, Name alias) {
-    super(name, Type.CNAME, dclass, ttl, alias, "alias");
+  public CNAMERecord(Name name, int dclass, long ttl, Name target) {
+    super(name, Type.CNAME, dclass, ttl, target, "target");
   }
 
   /** Gets the target of the CNAME Record */


### PR DESCRIPTION
The `CNAMERecord` class has a constructor parameter for the CNAME target which is called `alias` at the moment. This is quite confusing, because:

- The API docs states that this parameter is "The name to which the CNAME alias points". So it is NOT the alias itself (which is the name of the record), but the target to which the record points.
- There is a deprecated method `CNAMERecord#getAlias()` which does NOT return the value supplied with the `alias` constructor parameter, but returns the name of the record instead.

I think it would be help to rename this parameter to `target`. That is also consistent with the name used in `NSRecord` and  `PTRRecord`.